### PR TITLE
Add a std::map for leap-second insertions for improved handling

### DIFF
--- a/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/cam/cam_setters.h
+++ b/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/cam/cam_setters.h
@@ -54,9 +54,9 @@ namespace access {
    *
    * @param generation_delta_time GenerationDeltaTime to set the GenerationDeltaTime-Value for
    * @param unix_nanosecs Timestamp in unix-nanoseconds to set the GenerationDeltaTime-Value from
-   * @param n_leap_seconds Number of leap seconds since 2004 for the given timestamp (Default: etsi_its_msgs::N_LEAP_SECONDS)
+   * @param n_leap_seconds Number of leap seconds since 2004 for the given timestamp (Default: etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second)
    */
-  inline void setGenerationDeltaTime(GenerationDeltaTime& generation_delta_time, const uint64_t unix_nanosecs, const uint16_t n_leap_seconds = etsi_its_msgs::N_LEAP_SECONDS) {
+  inline void setGenerationDeltaTime(GenerationDeltaTime& generation_delta_time, const uint64_t unix_nanosecs, const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second) {
     TimestampIts t_its;
     cdd::setTimestampITS(t_its, unix_nanosecs, n_leap_seconds);
     uint16_t gdt_value = t_its.value%65536;
@@ -69,9 +69,9 @@ namespace access {
    *
    * @param cam CAM to set the GenerationDeltaTime-Value for
    * @param unix_nanosecs Timestamp in unix-nanoseconds to set the GenerationDeltaTime-Value from
-   * @param n_leap_seconds Number of leap seconds since 2004 for the given timestamp  (Default: etsi_its_msgs::N_LEAP_SECONDS)
+   * @param n_leap_seconds Number of leap seconds since 2004 for the given timestamp  (Default: etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second)
    */
-  inline void setGenerationDeltaTime(CAM& cam, const uint64_t unix_nanosecs, const uint16_t n_leap_seconds = etsi_its_msgs::N_LEAP_SECONDS) {
+  inline void setGenerationDeltaTime(CAM& cam, const uint64_t unix_nanosecs, const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second) {
     setGenerationDeltaTime(cam.cam.generation_delta_time, unix_nanosecs, n_leap_seconds);
   }
 

--- a/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/cam/cam_utils.h
+++ b/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/cam/cam_utils.h
@@ -59,10 +59,10 @@ namespace access {
    *
    * @param generation_delta_time the GenerationDeltaTime object to get the Unix-Nanoseconds from
    * @param timestamp_estimate estimated time to calculate the corresponding generation from
-   * @param n_leap_seconds number of leap-seconds since 2004. (Default: etsi_its_msgs::N_LEAP_SECONDS)
+   * @param n_leap_seconds number of leap-seconds since 2004. (Default: etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second)
    * @return uint64_t the corresponding Unix-Nanoseconds
    */
-  inline uint64_t getUnixNanosecondsFromGenerationDeltaTime(const GenerationDeltaTime& generation_delta_time, const TimestampIts& timestamp_estimate, const uint16_t n_leap_seconds = etsi_its_msgs::N_LEAP_SECONDS)
+  inline uint64_t getUnixNanosecondsFromGenerationDeltaTime(const GenerationDeltaTime& generation_delta_time, const TimestampIts& timestamp_estimate, const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second)
   {
     TimestampIts t_its = getTimestampITSFromGenerationDeltaTime(generation_delta_time, timestamp_estimate);
     return t_its.value*1e6+etsi_its_msgs::UNIX_SECONDS_2004*1e9-n_leap_seconds*1e9;
@@ -75,7 +75,7 @@ namespace access {
    * @param unix_timestamp_estimate estimated unix-time (in Nanoseconds) to calculate the corresponding generation from
    * @return uint64_t the corresponding Unix-Nanoseconds
    */
-  inline uint64_t getUnixNanosecondsFromGenerationDeltaTime(const GenerationDeltaTime& generation_delta_time, const uint64_t unix_timestamp_estimate, const uint16_t n_leap_seconds = etsi_its_msgs::N_LEAP_SECONDS)
+  inline uint64_t getUnixNanosecondsFromGenerationDeltaTime(const GenerationDeltaTime& generation_delta_time, const uint64_t unix_timestamp_estimate, const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second)
   {
     TimestampIts t_its;
     cdd::setTimestampITS(t_its, unix_timestamp_estimate, n_leap_seconds);

--- a/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/cdd/cdd_setters.h
+++ b/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/cdd/cdd_setters.h
@@ -57,10 +57,10 @@ namespace cdd_access {
    *
    * @param[in] timestamp_its TimestampITS object to set the timestamp
    * @param[in] unix_nanosecs Unix-Nanoseconds to set the timestamp for
-   * @param[in] n_leap_seconds Number of leap-seconds since 2004. (Default: etsi_its_msgs::N_LEAP_SECONDS)
+   * @param[in] n_leap_seconds Number of leap-seconds since 2004. (Default: etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second)
    * @param[in] epoch_offset Unix-Timestamp in seconds for the 01.01.2004 at 00:00:00
    */
-  inline void setTimestampITS(TimestampIts& timestamp_its, const uint64_t unix_nanosecs, const uint16_t n_leap_seconds = etsi_its_msgs::N_LEAP_SECONDS) {
+  inline void setTimestampITS(TimestampIts& timestamp_its, const uint64_t unix_nanosecs, const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second) {
     uint64_t t_its = unix_nanosecs*1e-6 + (uint64_t)(n_leap_seconds*1e3) - etsi_its_msgs::UNIX_SECONDS_2004*1e3;
     throwIfOutOfRange(t_its, TimestampIts::MIN, TimestampIts::MAX, "TimestampIts");
     timestamp_its.value = t_its;

--- a/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/constants.h
+++ b/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/constants.h
@@ -31,9 +31,42 @@ SOFTWARE.
 
 #pragma once
 
+#include <iostream>
+#include <map>
+
 namespace etsi_its_msgs {
 
-const int N_LEAP_SECONDS = 5; // 5 lead seconds for 2023
 const uint64_t UNIX_SECONDS_2004 = 1072915200; // Unix-Seconds for 2004-01-01T00:00:00.000Z
+const std::map<uint64_t, uint16_t> LEAP_SECOND_INSERTIONS_SINCE_2004 {
+    {UNIX_SECONDS_2004, 0},
+    {1136069999, 1}, // 31.12.2005 23:59:59
+    {1230764399, 2}, // 31.12.2008 23:59:59
+    {1341093599, 3}, // 30.06.2012 23:59:59
+    {1435701599, 4}, // 30.06.2015 23:59:59
+    {1483225199, 5}  // 31.12.2016 23:59:59
+};
+
+/**
+ * @brief Get the leap second insertions since 2004 for given unix seconds
+ * 
+ * @param unix_seconds
+ * @return uint16_t the number of leap second insertions since 2004 for unix_seconds
+ */
+inline uint16_t getLeapSecondInsertionsSince2004(const uint64_t unix_seconds)
+{
+    // Check if the map is empty
+    if (LEAP_SECOND_INSERTIONS_SINCE_2004.empty()) {
+        std::cerr << "WARN: LEAP_SECOND_INSERTIONS_SINCE_2004 is empty!" << std::endl;
+        return 0;
+    }
+
+    auto it = LEAP_SECOND_INSERTIONS_SINCE_2004.upper_bound(unix_seconds); // Find the first element greater than givenUnixSecond
+    if (it == LEAP_SECOND_INSERTIONS_SINCE_2004.begin()) {
+        std::cerr << "Given unix_second is smaller than all keys in the map!" << std::endl;
+        return 0;
+    }
+    --it; // Move iterator to the element with a key less than or equal to givenUnixSecond
+    return it->second; // Return the corresponding value
+}
 
 } // namespace etsi_its_msgs

--- a/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/constants.h
+++ b/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/constants.h
@@ -60,16 +60,9 @@ const std::map<uint64_t, uint16_t> LEAP_SECOND_INSERTIONS_SINCE_2004 {
 inline uint16_t getLeapSecondInsertionsSince2004(const uint64_t unix_seconds)
 {
     // Check if the map is empty
-    if (LEAP_SECOND_INSERTIONS_SINCE_2004.empty()) {
-        std::cerr << "WARNING: LEAP_SECOND_INSERTIONS_SINCE_2004 is empty!" << std::endl;
-        return 0;
-    }
-
+    if (LEAP_SECOND_INSERTIONS_SINCE_2004.empty()) return 0;
     auto it = LEAP_SECOND_INSERTIONS_SINCE_2004.upper_bound(unix_seconds); // Find the first element greater than givenUnixSecond
-    if (it == LEAP_SECOND_INSERTIONS_SINCE_2004.begin()) {
-        std::cerr << "WARNING: Given unix_second is smaller than all keys in LEAP_SECOND_INSERTIONS_SINCE_2004!" << std::endl;
-        return 0;
-    }
+    if (it == LEAP_SECOND_INSERTIONS_SINCE_2004.begin()) return 0;
     --it; // Move iterator to the element with a key less than or equal to givenUnixSecond
     return it->second; // Return the corresponding value
 }

--- a/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/constants.h
+++ b/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/constants.h
@@ -54,20 +54,20 @@ const std::map<uint64_t, uint16_t> LEAP_SECOND_INSERTIONS_SINCE_2004 {
 /**
  * @brief Get the leap second insertions since 2004 for given unix seconds
  * 
- * @param unix_seconds
+ * @param unix_seconds the current unix seconds for that the leap second insertions since 2004 shall be provided
  * @return uint16_t the number of leap second insertions since 2004 for unix_seconds
  */
 inline uint16_t getLeapSecondInsertionsSince2004(const uint64_t unix_seconds)
 {
     // Check if the map is empty
     if (LEAP_SECOND_INSERTIONS_SINCE_2004.empty()) {
-        std::cerr << "WARN: LEAP_SECOND_INSERTIONS_SINCE_2004 is empty!" << std::endl;
+        std::cerr << "WARNING: LEAP_SECOND_INSERTIONS_SINCE_2004 is empty!" << std::endl;
         return 0;
     }
 
     auto it = LEAP_SECOND_INSERTIONS_SINCE_2004.upper_bound(unix_seconds); // Find the first element greater than givenUnixSecond
     if (it == LEAP_SECOND_INSERTIONS_SINCE_2004.begin()) {
-        std::cerr << "Given unix_second is smaller than all keys in the map!" << std::endl;
+        std::cerr << "WARNING: Given unix_second is smaller than all keys in LEAP_SECOND_INSERTIONS_SINCE_2004!" << std::endl;
         return 0;
     }
     --it; // Move iterator to the element with a key less than or equal to givenUnixSecond

--- a/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/constants.h
+++ b/etsi_its_msgs/etsi_its_msgs/include/etsi_its_msgs/impl/constants.h
@@ -37,13 +37,18 @@ SOFTWARE.
 namespace etsi_its_msgs {
 
 const uint64_t UNIX_SECONDS_2004 = 1072915200; // Unix-Seconds for 2004-01-01T00:00:00.000Z
+
+/**
+ * @brief std::map that stores all leap second insertions since 2004 with the corresponding unix-date of the insertion
+ * 
+ */
 const std::map<uint64_t, uint16_t> LEAP_SECOND_INSERTIONS_SINCE_2004 {
     {UNIX_SECONDS_2004, 0},
-    {1136069999, 1}, // 31.12.2005 23:59:59
-    {1230764399, 2}, // 31.12.2008 23:59:59
-    {1341093599, 3}, // 30.06.2012 23:59:59
-    {1435701599, 4}, // 30.06.2015 23:59:59
-    {1483225199, 5}  // 31.12.2016 23:59:59
+    {1136073599, 1}, // 2005-12-31T23:59:59.000Z
+    {1230767999, 2}, // 2008-12-31T23:59:59.000Z
+    {1341100799, 3}, // 2012-06-30T23:59:59.000Z
+    {1435708799, 4}, // 2015-06-30T23:59:59.000Z
+    {1483228799, 5}  // 2016-12-31T23:59:59.000Z
 };
 
 /**

--- a/etsi_its_msgs/etsi_its_msgs/test/impl/test_cam_access.cpp
+++ b/etsi_its_msgs/etsi_its_msgs/test/impl/test_cam_access.cpp
@@ -37,16 +37,17 @@ TEST(etsi_its_cam_msgs, test_set_get_cam) {
   // since 2004-01-01T00:00:00.000Z.
   uint64_t t_2007 = ((uint64_t)1167609600)*1e9;
   TimestampIts t_its;
-  etsi_its_msgs::cdd_access::setTimestampITS(t_its, t_2007, 1);
+  EXPECT_EQ(1, etsi_its_msgs::getLeapSecondInsertionsSince2004(t_2007*1e-9));
+  etsi_its_msgs::cdd_access::setTimestampITS(t_its, t_2007, etsi_its_msgs::getLeapSecondInsertionsSince2004(t_2007*1e-9));
   EXPECT_EQ(94694401000, t_its.value);
-  setGenerationDeltaTime(cam, t_2007, 1);
+  setGenerationDeltaTime(cam, t_2007, etsi_its_msgs::getLeapSecondInsertionsSince2004(t_2007*1e-9));
   EXPECT_EQ(94694401000%65536, getGenerationDeltaTimeValue(cam));
   TimestampIts t_its2;
   uint64_t t_2007_off = t_2007 + 5*1e9;
-  etsi_its_msgs::cdd_access::setTimestampITS(t_its2, t_2007_off, 1);
+  etsi_its_msgs::cdd_access::setTimestampITS(t_its2, t_2007_off, etsi_its_msgs::getLeapSecondInsertionsSince2004(t_2007*1e-9));
   EXPECT_EQ(94694401000, getTimestampITSFromGenerationDeltaTime(getGenerationDeltaTime(cam), t_its2).value);
-  EXPECT_EQ(t_2007, getUnixNanosecondsFromGenerationDeltaTime(getGenerationDeltaTime(cam), t_its2, 1));
-  EXPECT_EQ(t_2007, getUnixNanosecondsFromGenerationDeltaTime(getGenerationDeltaTime(cam), t_2007_off, 1));
+  EXPECT_EQ(t_2007, getUnixNanosecondsFromGenerationDeltaTime(getGenerationDeltaTime(cam), t_its2, etsi_its_msgs::getLeapSecondInsertionsSince2004(t_2007*1e-9)));
+  EXPECT_EQ(t_2007, getUnixNanosecondsFromGenerationDeltaTime(getGenerationDeltaTime(cam), t_2007_off, etsi_its_msgs::getLeapSecondInsertionsSince2004(t_2007*1e-9)));
 
   int stationType_val = randomInt(StationType::MIN, StationType::MAX);
   setStationType(cam, stationType_val);

--- a/etsi_its_rviz_plugins/include/displays/CAM/cam_render_object.hpp
+++ b/etsi_its_rviz_plugins/include/displays/CAM/cam_render_object.hpp
@@ -45,7 +45,7 @@ namespace displays
 class CAMRenderObject
 {
   public:
-    CAMRenderObject(etsi_its_cam_msgs::msg::CAM cam, rclcpp::Time receive_time, uint16_t n_leap_seconds=etsi_its_msgs::N_LEAP_SECONDS);
+    CAMRenderObject(etsi_its_cam_msgs::msg::CAM cam, rclcpp::Time receive_time, uint16_t n_leap_seconds=etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second);
 
     /**
      * @brief This function validates all float variables that are part of a CAMRenderObject

--- a/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
@@ -100,7 +100,8 @@ void CAMDisplay::reset()
 void CAMDisplay::processMessage(etsi_its_cam_msgs::msg::CAM::ConstSharedPtr msg)
 {
   // Generate CAM render object from message
-  CAMRenderObject cam(*msg, rviz_node_->now(), 5); // 5 leap seconds in 2023
+  rclcpp::Time now = rviz_node_->now();
+  CAMRenderObject cam(*msg, now, getLeapSecondInsertionsSince2004((uint64_t)now.seconds()));
   if (!cam.validateFloats()) {
         setStatus(
           rviz_common::properties::StatusProperty::Error, "Topic",


### PR DESCRIPTION
This PR adds a std::map including a getter-function for the leap seconds since 2004 for a given unix second. The RViz display plugin for cams and the tests have been adapted accordingly.