### PR TITLE
Improve configuration of conversion node

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@
 
 All message definitions and conversion functions are automatically generated based on the [ASN.1 definitions](https://forge.etsi.org/rep/ITS/asn1) of the standardized ETSI ITS messages.
 
-> [!IMPORTANT]
-> This repository is open-sourced and maintained by the [**Institute for Automotive Engineering (ika) at RWTH Aachen University**](https://www.ika.rwth-aachen.de/).
-> **V2X Communication** is one of many research topics within our [*Vehicle Intelligence & Automated Driving*](https://www.ika.rwth-aachen.de/en/competences/fields-of-research/vehicle-intelligence-automated-driving.html) domain.
-> If you would like to learn more about how we can support your advanced driver assistance and automated driving efforts, feel free to reach out to us!
-> &nbsp;&nbsp;&nbsp;&nbsp; *Timo Woopen - Manager Research Area Vehicle Intelligence & Automated Driving*
-> &nbsp;&nbsp;&nbsp;&nbsp; *+49 241 80 23549*
-> &nbsp;&nbsp;&nbsp;&nbsp; *timo.woopen@ika.rwth-aachen.de*
+> [!IMPORTANT]  
+> This repository is open-sourced and maintained by the [**Institute for Automotive Engineering (ika) at RWTH Aachen University**](https://www.ika.rwth-aachen.de/).  
+> **V2X Communication** is one of many research topics within our [*Vehicle Intelligence & Automated Driving*](https://www.ika.rwth-aachen.de/en/competences/fields-of-research/vehicle-intelligence-automated-driving.html) domain.  
+> If you would like to learn more about how we can support your advanced driver assistance and automated driving efforts, feel free to reach out to us!  
+> &nbsp;&nbsp;&nbsp;&nbsp; *Timo Woopen - Manager Research Area Vehicle Intelligence & Automated Driving*  
+> &nbsp;&nbsp;&nbsp;&nbsp; *+49 241 80 23549*  
+> &nbsp;&nbsp;&nbsp;&nbsp; *timo.woopen@ika.rwth-aachen.de*  
 
 - [etsi\_its\_messages](#etsi_its_messages)
   - [Concept](#concept)
@@ -149,12 +149,12 @@ The conversion node bridges all ETSI ITS message types at the same time in both 
 # ROS 2
 ros2 launch etsi_its_conversion converter.launch.py
 # or
-ros2 run etsi_its_conversion etsi_its_conversion_node --ros-args -p etsi_types:=[cam,denm] -p has_btp_destination_port:=true -p btp_destination_port_offset:=0 -p etsi_message_payload_offset:=4
+ros2 run etsi_its_conversion etsi_its_conversion_node --ros-args -p etsi_types:=[cam,denm] -p has_btp_destination_port:=true -p btp_destination_port_offset:=8 -p etsi_message_payload_offset:=78
 
 # ROS
 roslaunch etsi_its_conversion converter.ros1.launch
 # or
-rosrun nodelet nodelet standalone etsi_its_conversion/Converter _etsi_types:=[cam,denm] _has_btp_destination_port:=true _btp_destination_port_offset:=0 _etsi_message_payload_offset:=4
+rosrun nodelet nodelet standalone etsi_its_conversion/Converter _etsi_types:=[cam,denm] _has_btp_destination_port:=true _btp_destination_port_offset:=8 _etsi_message_payload_offset:=78
 ```
 
 ##### Subscribed Topics

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@
 
 All message definitions and conversion functions are automatically generated based on the [ASN.1 definitions](https://forge.etsi.org/rep/ITS/asn1) of the standardized ETSI ITS messages.
 
-> [!IMPORTANT]  
-> This repository is open-sourced and maintained by the [**Institute for Automotive Engineering (ika) at RWTH Aachen University**](https://www.ika.rwth-aachen.de/).  
-> **V2X Communication** is one of many research topics within our [*Vehicle Intelligence & Automated Driving*](https://www.ika.rwth-aachen.de/en/competences/fields-of-research/vehicle-intelligence-automated-driving.html) domain.  
-> If you would like to learn more about how we can support your advanced driver assistance and automated driving efforts, feel free to reach out to us!  
-> &nbsp;&nbsp;&nbsp;&nbsp; *Timo Woopen - Manager Research Area Vehicle Intelligence & Automated Driving*  
-> &nbsp;&nbsp;&nbsp;&nbsp; *+49 241 80 23549*  
-> &nbsp;&nbsp;&nbsp;&nbsp; *timo.woopen@ika.rwth-aachen.de*  
+> [!IMPORTANT]
+> This repository is open-sourced and maintained by the [**Institute for Automotive Engineering (ika) at RWTH Aachen University**](https://www.ika.rwth-aachen.de/).
+> **V2X Communication** is one of many research topics within our [*Vehicle Intelligence & Automated Driving*](https://www.ika.rwth-aachen.de/en/competences/fields-of-research/vehicle-intelligence-automated-driving.html) domain.
+> If you would like to learn more about how we can support your advanced driver assistance and automated driving efforts, feel free to reach out to us!
+> &nbsp;&nbsp;&nbsp;&nbsp; *Timo Woopen - Manager Research Area Vehicle Intelligence & Automated Driving*
+> &nbsp;&nbsp;&nbsp;&nbsp; *+49 241 80 23549*
+> &nbsp;&nbsp;&nbsp;&nbsp; *timo.woopen@ika.rwth-aachen.de*
 
 - [etsi\_its\_messages](#etsi_its_messages)
   - [Concept](#concept)
@@ -149,12 +149,12 @@ The conversion node bridges all ETSI ITS message types at the same time in both 
 # ROS 2
 ros2 launch etsi_its_conversion converter.launch.py
 # or
-ros2 run etsi_its_conversion etsi_its_conversion_node --ros-args -p etsi_type:=auto
+ros2 run etsi_its_conversion etsi_its_conversion_node --ros-args -p has_btp_header:=true -p etsi_types:=[cam,denm]
 
 # ROS
 roslaunch etsi_its_conversion converter.ros1.launch
 # or
-rosrun nodelet nodelet standalone etsi_its_conversion/Converter _etsi_type:=auto
+rosrun nodelet nodelet standalone etsi_its_conversion/Converter _etsi_types:=[cam,denm]
 ```
 
 ##### Subscribed Topics
@@ -177,7 +177,8 @@ rosrun nodelet nodelet standalone etsi_its_conversion/Converter _etsi_type:=auto
 
 | Parameter | Type | Description | Options |
 | --- | --- | --- | --- |
-| `etsi_type` | `string` | if set to `auto`, in- and outgoing UDP payloads are expected to include a [4-byte BTP header](https://www.etsi.org/deliver/etsi_en/302600_302699/3026360501/02.01.00_20/en_3026360501v020100a.pdf) | `auto`, `cam`, `denm` |
+| `has_btp_header` | `bool` | whether incoming/outgoing UDP messages include a [4-byte BTP header](https://www.etsi.org/deliver/etsi_en/302600_302699/3026360501/02.01.00_20/en_3026360501v020100a.pdf) |
+| `etsi_types` | `string[]` | list of ETSI types to convert | `cam`, `denm` |
 
 
 #### Automated Generation

--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ The conversion node bridges all ETSI ITS message types at the same time in both 
 # ROS 2
 ros2 launch etsi_its_conversion converter.launch.py
 # or
-ros2 run etsi_its_conversion etsi_its_conversion_node --ros-args -p has_btp_header:=true -p etsi_types:=[cam,denm]
+ros2 run etsi_its_conversion etsi_its_conversion_node --ros-args -p etsi_types:=[cam,denm] -p has_btp_header:=true -p incoming_payload_offset:=0
 
 # ROS
 roslaunch etsi_its_conversion converter.ros1.launch
 # or
-rosrun nodelet nodelet standalone etsi_its_conversion/Converter _etsi_types:=[cam,denm]
+rosrun nodelet nodelet standalone etsi_its_conversion/Converter _etsi_types:=[cam,denm] _has_btp_header:=true _incoming_payload_offset:=0
 ```
 
 ##### Subscribed Topics
@@ -177,6 +177,7 @@ rosrun nodelet nodelet standalone etsi_its_conversion/Converter _etsi_types:=[ca
 
 | Parameter | Type | Description | Options |
 | --- | --- | --- | --- |
+| `incoming_payload_offset` | `int` | number of bytes until actual message payload starts in incoming UDP message (optionally including BTP header, see `has_btp_header`) |
 | `has_btp_header` | `bool` | whether incoming/outgoing UDP messages include a [4-byte BTP header](https://www.etsi.org/deliver/etsi_en/302600_302699/3026360501/02.01.00_20/en_3026360501v020100a.pdf) |
 | `etsi_types` | `string[]` | list of ETSI types to convert | `cam`, `denm` |
 

--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ The conversion node bridges all ETSI ITS message types at the same time in both 
 # ROS 2
 ros2 launch etsi_its_conversion converter.launch.py
 # or
-ros2 run etsi_its_conversion etsi_its_conversion_node --ros-args -p etsi_types:=[cam,denm] -p has_btp_header:=true -p incoming_payload_offset:=0
+ros2 run etsi_its_conversion etsi_its_conversion_node --ros-args -p etsi_types:=[cam,denm] -p has_btp_destination_port:=true -p btp_destination_port_offset:=0 -p etsi_message_payload_offset:=4
 
 # ROS
 roslaunch etsi_its_conversion converter.ros1.launch
 # or
-rosrun nodelet nodelet standalone etsi_its_conversion/Converter _etsi_types:=[cam,denm] _has_btp_header:=true _incoming_payload_offset:=0
+rosrun nodelet nodelet standalone etsi_its_conversion/Converter _etsi_types:=[cam,denm] _has_btp_destination_port:=true _btp_destination_port_offset:=0 _etsi_message_payload_offset:=4
 ```
 
 ##### Subscribed Topics
@@ -177,8 +177,9 @@ rosrun nodelet nodelet standalone etsi_its_conversion/Converter _etsi_types:=[ca
 
 | Parameter | Type | Description | Options |
 | --- | --- | --- | --- |
-| `incoming_payload_offset` | `int` | number of bytes until actual message payload starts in incoming UDP message (optionally including BTP header, see `has_btp_header`) |
-| `has_btp_header` | `bool` | whether incoming/outgoing UDP messages include a [4-byte BTP header](https://www.etsi.org/deliver/etsi_en/302600_302699/3026360501/02.01.00_20/en_3026360501v020100a.pdf) |
+| `has_btp_destination_port` | `bool` | whether incoming/outgoing UDP messages include a [2-byte BTP destination port](https://www.etsi.org/deliver/etsi_en/302600_302699/3026360501/02.01.00_20/en_3026360501v020100a.pdf) |
+| `btp_destination_port_offset` | `int` | number of bytes before an optional 2-byte BTP destination port, see `has_btp_destination_port` |
+| `etsi_message_payload_offset` | `int` | number of bytes before actual ETSI message payload |
 | `etsi_types` | `string[]` | list of ETSI types to convert | `cam`, `denm` |
 
 

--- a/etsi_its_conversion/etsi_its_conversion/config/params.ros1.yml
+++ b/etsi_its_conversion/etsi_its_conversion/config/params.ros1.yml
@@ -1,1 +1,4 @@
-etsi_type: auto
+has_btp_header: true
+etsi_types:
+  - cam
+  - denm

--- a/etsi_its_conversion/etsi_its_conversion/config/params.ros1.yml
+++ b/etsi_its_conversion/etsi_its_conversion/config/params.ros1.yml
@@ -1,6 +1,6 @@
 has_btp_destination_port: true
-btp_destination_port_offset: 0
-etsi_message_payload_offset: 4
+btp_destination_port_offset: 8  # default for Cohda Wireless MK-5 exampleETSI application
+etsi_message_payload_offset: 78 # default for Cohda Wireless MK-5 exampleETSI application
 etsi_types:
   - cam
   - denm

--- a/etsi_its_conversion/etsi_its_conversion/config/params.ros1.yml
+++ b/etsi_its_conversion/etsi_its_conversion/config/params.ros1.yml
@@ -1,5 +1,6 @@
-incoming_payload_offset: 0
-has_btp_header: true
+has_btp_destination_port: true
+btp_destination_port_offset: 0
+etsi_message_payload_offset: 4
 etsi_types:
   - cam
   - denm

--- a/etsi_its_conversion/etsi_its_conversion/config/params.ros1.yml
+++ b/etsi_its_conversion/etsi_its_conversion/config/params.ros1.yml
@@ -1,3 +1,4 @@
+incoming_payload_offset: 0
 has_btp_header: true
 etsi_types:
   - cam

--- a/etsi_its_conversion/etsi_its_conversion/config/params.yml
+++ b/etsi_its_conversion/etsi_its_conversion/config/params.yml
@@ -1,7 +1,8 @@
 etsi_its_conversion:
   ros__parameters:
-    incoming_payload_offset: 0
-    has_btp_header: true
+    has_btp_destination_port: true
+    btp_destination_port_offset: 0
+    etsi_message_payload_offset: 4
     etsi_types:
       - cam
       - denm

--- a/etsi_its_conversion/etsi_its_conversion/config/params.yml
+++ b/etsi_its_conversion/etsi_its_conversion/config/params.yml
@@ -1,5 +1,6 @@
 etsi_its_conversion:
   ros__parameters:
+    incoming_payload_offset: 0
     has_btp_header: true
     etsi_types:
       - cam

--- a/etsi_its_conversion/etsi_its_conversion/config/params.yml
+++ b/etsi_its_conversion/etsi_its_conversion/config/params.yml
@@ -1,3 +1,6 @@
 etsi_its_conversion:
   ros__parameters:
-    etsi_type: auto
+    has_btp_header: true
+    etsi_types:
+      - cam
+      - denm

--- a/etsi_its_conversion/etsi_its_conversion/config/params.yml
+++ b/etsi_its_conversion/etsi_its_conversion/config/params.yml
@@ -1,8 +1,8 @@
 etsi_its_conversion:
   ros__parameters:
     has_btp_destination_port: true
-    btp_destination_port_offset: 0
-    etsi_message_payload_offset: 4
+    btp_destination_port_offset: 8  # default for Cohda Wireless MK-5 exampleETSI application
+    etsi_message_payload_offset: 78 # default for Cohda Wireless MK-5 exampleETSI application
     etsi_types:
       - cam
       - denm

--- a/etsi_its_conversion/etsi_its_conversion/include/etsi_its_conversion/Converter.hpp
+++ b/etsi_its_conversion/etsi_its_conversion/include/etsi_its_conversion/Converter.hpp
@@ -92,11 +92,14 @@ class Converter : public rclcpp::Node {
     static const std::string kInputTopicDenm;
     static const std::string kOutputTopicDenm;
 
+    static const std::string kIncomingPayloadOffset;
+    static const int kIncomingPayloadOffsetDefault;
     static const std::string kHasBtpHeaderParam;
     static const bool kHasBtpHeaderParamDefault;
     static const std::string kEtsiTypesParam;
     static const std::vector<std::string> kEtsiTypesParamDefault;
 
+    int incoming_payload_offset_;
     bool has_btp_header_;
     std::vector<std::string> etsi_types_;
 

--- a/etsi_its_conversion/etsi_its_conversion/include/etsi_its_conversion/Converter.hpp
+++ b/etsi_its_conversion/etsi_its_conversion/include/etsi_its_conversion/Converter.hpp
@@ -92,10 +92,13 @@ class Converter : public rclcpp::Node {
     static const std::string kInputTopicDenm;
     static const std::string kOutputTopicDenm;
 
-    static const std::string kEtsiTypeParam;
-    static const std::string kEtsiTypeParamDefault;
+    static const std::string kHasBtpHeaderParam;
+    static const bool kHasBtpHeaderParamDefault;
+    static const std::string kEtsiTypesParam;
+    static const std::vector<std::string> kEtsiTypesParamDefault;
 
-    std::string etsi_type_;
+    bool has_btp_header_;
+    std::vector<std::string> etsi_types_;
 
 #ifdef ROS1
     ros::NodeHandle private_node_handle_;

--- a/etsi_its_conversion/etsi_its_conversion/include/etsi_its_conversion/Converter.hpp
+++ b/etsi_its_conversion/etsi_its_conversion/include/etsi_its_conversion/Converter.hpp
@@ -92,15 +92,18 @@ class Converter : public rclcpp::Node {
     static const std::string kInputTopicDenm;
     static const std::string kOutputTopicDenm;
 
-    static const std::string kIncomingPayloadOffset;
-    static const int kIncomingPayloadOffsetDefault;
-    static const std::string kHasBtpHeaderParam;
-    static const bool kHasBtpHeaderParamDefault;
+    static const std::string kHasBtpDestinationPortParam;
+    static const bool kHasBtpDestinationPortParamDefault;
+    static const std::string kBtpDestinationPortOffsetParam;
+    static const int kBtpDestinationPortOffsetParamDefault;
+    static const std::string kEtsiMessagePayloadOffsetParam;
+    static const int kEtsiMessagePayloadOffsetParamDefault;
     static const std::string kEtsiTypesParam;
     static const std::vector<std::string> kEtsiTypesParamDefault;
 
-    int incoming_payload_offset_;
-    bool has_btp_header_;
+    bool has_btp_destination_port_;
+    int btp_destination_port_offset_;
+    int etsi_message_payload_offset_;
     std::vector<std::string> etsi_types_;
 
 #ifdef ROS1

--- a/etsi_its_conversion/etsi_its_conversion/src/Converter.cpp
+++ b/etsi_its_conversion/etsi_its_conversion/src/Converter.cpp
@@ -71,9 +71,9 @@ const std::string Converter::kOutputTopicDenm{"~/denm/out"};
 const std::string Converter::kHasBtpDestinationPortParam{"has_btp_destination_port"};
 const bool Converter::kHasBtpDestinationPortParamDefault{true};
 const std::string Converter::kBtpDestinationPortOffsetParam{"btp_destination_port_offset"};
-const int Converter::kBtpDestinationPortOffsetParamDefault{0};
+const int Converter::kBtpDestinationPortOffsetParamDefault{8};
 const std::string Converter::kEtsiMessagePayloadOffsetParam{"etsi_message_payload_offset"};
-const int Converter::kEtsiMessagePayloadOffsetParamDefault{4};
+const int Converter::kEtsiMessagePayloadOffsetParamDefault{78};
 const std::string Converter::kEtsiTypesParam{"etsi_types"};
 const std::vector<std::string> Converter::kEtsiTypesParamDefault{"cam", "denm"};
 


### PR DESCRIPTION
- adds parameter to set a fixed payload offset in conversion node; useful if payload is always prefixed by a vendor-specific header
- adds parameter to choose which types to convert in conversion node
- this is a breaking change for conversion node parameter handling