### PR TITLE
Fix GitHub CI by enabling recursive checkout

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -56,6 +58,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -85,6 +89,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - name: Set up Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
- codegen jobs were failing because submodules were not checked out
- issue didn't appear before because the jobs were working with the reduced asn1 files stored in the repository
- with https://github.com/ika-rwth-aachen/etsi_its_messages/commit/99ae5a591c77b55d3daeacb7c858770365621e49, reducing was removed