### PR TITLE
Fix ROS Buildfarm Failures

### DIFF
--- a/etsi_its_conversion/etsi_its_primitives_conversion/include/etsi_its_primitives_conversion/convertINTEGER.h
+++ b/etsi_its_conversion/etsi_its_primitives_conversion/include/etsi_its_primitives_conversion/convertINTEGER.h
@@ -67,7 +67,7 @@ namespace etsi_its_primitives_conversion {
   }
 
   void toStruct_INTEGER(const int64_t& _INTEGER_in, unsigned long& INTEGER_out) {
-    if (_INTEGER_IN < 0)
+    if (_INTEGER_in < 0)
       throw std::range_error("Failed to convert int64_t to unsigned long");
     INTEGER_out = static_cast<unsigned long>(_INTEGER_in);
   }

--- a/etsi_its_conversion/etsi_its_primitives_conversion/include/etsi_its_primitives_conversion/convertINTEGER.h
+++ b/etsi_its_conversion/etsi_its_primitives_conversion/include/etsi_its_primitives_conversion/convertINTEGER.h
@@ -34,7 +34,7 @@ namespace etsi_its_primitives_conversion {
     long out;
     int status = asn_INTEGER2long(&_INTEGER_in, &out);
     if (status != 0)
-      throw std::range_error("Failed to convert INTEGER_t to long");
+      throw std::range_error("Failed to convert INTEGER_t to int64_t");
     INTEGER_out = static_cast<int64_t>(out);
   }
 
@@ -43,14 +43,14 @@ namespace etsi_its_primitives_conversion {
     unsigned long out;
     int status = asn_INTEGER2ulong(&_INTEGER_in, &out);
     if (status != 0)
-      throw std::range_error("Failed to convert INTEGER_t to unsigned long");
+      throw std::range_error("Failed to convert INTEGER_t to uint64_t");
     INTEGER_out = static_cast<uint64_t>(out);
   }
 
   template <typename T>
-  void toRos_INTEGER(const int64_t& _INTEGER_in, T& INTEGER_out) {
+  void toRos_INTEGER(const long& _INTEGER_in, T& INTEGER_out) {
     if (std::numeric_limits<T>::max() < _INTEGER_in)
-      throw std::range_error("Failed to convert int64_t (" + std::to_string(_INTEGER_in) + ") to smaller integer type (max: " + std::to_string(std::numeric_limits<T>::max()) + ")");
+      throw std::range_error("Failed to convert long (" + std::to_string(_INTEGER_in) + ") to smaller integer type (max: " + std::to_string(std::numeric_limits<T>::max()) + ")");
     INTEGER_out = static_cast<T>(_INTEGER_in);
   }
 
@@ -59,14 +59,16 @@ namespace etsi_its_primitives_conversion {
     const long in = static_cast<long>(_INTEGER_in);
     int status = asn_long2INTEGER(&INTEGER_out, in);
     if (status != 0)
-      throw std::range_error("Failed to convert long to INTEGER_t");
+      throw std::range_error("Failed to convert int64_t to INTEGER_t");
   }
 
-  void toStruct_INTEGER(const int64_t& _INTEGER_in, int64_t& INTEGER_out) {
+  void toStruct_INTEGER(const int64_t& _INTEGER_in, long& INTEGER_out) {
     INTEGER_out = _INTEGER_in;
   }
 
-  void toStruct_INTEGER(const int64_t& _INTEGER_in, uint64_t& INTEGER_out) {
-    INTEGER_out = static_cast<uint64_t>(_INTEGER_in);
+  void toStruct_INTEGER(const int64_t& _INTEGER_in, unsigned long& INTEGER_out) {
+    if (_INTEGER_IN < 0)
+      throw std::range_error("Failed to convert int64_t to unsigned long");
+    INTEGER_out = static_cast<unsigned long>(_INTEGER_in);
   }
 }

--- a/etsi_its_conversion/etsi_its_primitives_conversion/include/etsi_its_primitives_conversion/convertINTEGER.h
+++ b/etsi_its_conversion/etsi_its_primitives_conversion/include/etsi_its_primitives_conversion/convertINTEGER.h
@@ -30,72 +30,43 @@ SOFTWARE.
 namespace etsi_its_primitives_conversion {
 
   template <typename T>
-  void toRos_INTEGER(const T& _INTEGER_in, long& INTEGER_out) {
-    int status = asn_INTEGER2long(&_INTEGER_in, &INTEGER_out);
-    if (status != 0)
-      throw std::range_error("Failed to convert INTEGER_t to long");
-  }
-
-  template <typename T>
-  void toRos_INTEGER(const T& _INTEGER_in, long long& INTEGER_out) {
+  void toRos_INTEGER(const T& _INTEGER_in, int64_t& INTEGER_out) {
     long out;
     int status = asn_INTEGER2long(&_INTEGER_in, &out);
     if (status != 0)
       throw std::range_error("Failed to convert INTEGER_t to long");
-    INTEGER_out = static_cast<long long>(out);
+    INTEGER_out = static_cast<int64_t>(out);
   }
 
   template <typename T>
-  void toRos_INTEGER(const T& _INTEGER_in, unsigned long& INTEGER_out) {
-    int status = asn_INTEGER2ulong(&_INTEGER_in, &INTEGER_out);
-    if (status != 0)
-      throw std::range_error("Failed to convert INTEGER_t to unsigned long");
-  }
-
-  template <typename T>
-  void toRos_INTEGER(const T& _INTEGER_in, unsigned long long& INTEGER_out) {
+  void toRos_INTEGER(const T& _INTEGER_in, uint64_t& INTEGER_out) {
     unsigned long out;
     int status = asn_INTEGER2ulong(&_INTEGER_in, &out);
     if (status != 0)
       throw std::range_error("Failed to convert INTEGER_t to unsigned long");
-    INTEGER_out = static_cast<unsigned long long>(out);
+    INTEGER_out = static_cast<uint64_t>(out);
   }
 
   template <typename T>
-  void toRos_INTEGER(const long& _INTEGER_in, T& INTEGER_out) {
+  void toRos_INTEGER(const int64_t& _INTEGER_in, T& INTEGER_out) {
     if (std::numeric_limits<T>::max() < _INTEGER_in)
-      throw std::range_error("Failed to convert long (" + std::to_string(_INTEGER_in) + ") to smaller integer type (max: " + std::to_string(std::numeric_limits<T>::max()) + ")");
-    INTEGER_out = _INTEGER_in;
+      throw std::range_error("Failed to convert int64_t (" + std::to_string(_INTEGER_in) + ") to smaller integer type (max: " + std::to_string(std::numeric_limits<T>::max()) + ")");
+    INTEGER_out = static_cast<T>(_INTEGER_in);
   }
 
   template <typename T>
-  void toStruct_INTEGER(const long& _INTEGER_in, T& INTEGER_out) {
-    int status = asn_long2INTEGER(&INTEGER_out, _INTEGER_in);
-    if (status != 0)
-      throw std::range_error("Failed to convert long to INTEGER_t");
-  }
-
-  template <typename T>
-  void toStruct_INTEGER(const long long& _INTEGER_in, T& INTEGER_out) {
+  void toStruct_INTEGER(const int64_t& _INTEGER_in, T& INTEGER_out) {
     const long in = static_cast<long>(_INTEGER_in);
     int status = asn_long2INTEGER(&INTEGER_out, in);
     if (status != 0)
       throw std::range_error("Failed to convert long to INTEGER_t");
   }
 
-  void toStruct_INTEGER(const long& _INTEGER_in, long& INTEGER_out) {
+  void toStruct_INTEGER(const int64_t& _INTEGER_in, int64_t& INTEGER_out) {
     INTEGER_out = _INTEGER_in;
   }
 
-  void toStruct_INTEGER(const long long& _INTEGER_in, long long& INTEGER_out) {
-    INTEGER_out = _INTEGER_in;
-  }
-  
-  void toStruct_INTEGER(const long& _INTEGER_in, unsigned long& INTEGER_out) {
-    INTEGER_out = static_cast<unsigned long>(_INTEGER_in);
-  }
-
-  void toStruct_INTEGER(const long long& _INTEGER_in, unsigned long long& INTEGER_out) {
-    INTEGER_out = static_cast<unsigned long long>(_INTEGER_in);
+  void toStruct_INTEGER(const int64_t& _INTEGER_in, uint64_t& INTEGER_out) {
+    INTEGER_out = static_cast<uint64_t>(_INTEGER_in);
   }
 }

--- a/etsi_its_conversion/etsi_its_primitives_conversion/include/etsi_its_primitives_conversion/convertINTEGER.h
+++ b/etsi_its_conversion/etsi_its_primitives_conversion/include/etsi_its_primitives_conversion/convertINTEGER.h
@@ -37,10 +37,28 @@ namespace etsi_its_primitives_conversion {
   }
 
   template <typename T>
+  void toRos_INTEGER(const T& _INTEGER_in, long long& INTEGER_out) {
+    long out;
+    int status = asn_INTEGER2long(&_INTEGER_in, &out);
+    if (status != 0)
+      throw std::range_error("Failed to convert INTEGER_t to long");
+    INTEGER_out = static_cast<long long>(out);
+  }
+
+  template <typename T>
   void toRos_INTEGER(const T& _INTEGER_in, unsigned long& INTEGER_out) {
     int status = asn_INTEGER2ulong(&_INTEGER_in, &INTEGER_out);
     if (status != 0)
       throw std::range_error("Failed to convert INTEGER_t to unsigned long");
+  }
+
+  template <typename T>
+  void toRos_INTEGER(const T& _INTEGER_in, unsigned long long& INTEGER_out) {
+    unsigned long out;
+    int status = asn_INTEGER2ulong(&_INTEGER_in, &out);
+    if (status != 0)
+      throw std::range_error("Failed to convert INTEGER_t to unsigned long");
+    INTEGER_out = static_cast<unsigned long long>(out);
   }
 
   template <typename T>
@@ -57,12 +75,27 @@ namespace etsi_its_primitives_conversion {
       throw std::range_error("Failed to convert long to INTEGER_t");
   }
 
+  template <typename T>
+  void toStruct_INTEGER(const long long& _INTEGER_in, T& INTEGER_out) {
+    const long in = static_cast<long>(_INTEGER_in);
+    int status = asn_long2INTEGER(&INTEGER_out, in);
+    if (status != 0)
+      throw std::range_error("Failed to convert long to INTEGER_t");
+  }
+
   void toStruct_INTEGER(const long& _INTEGER_in, long& INTEGER_out) {
+    INTEGER_out = _INTEGER_in;
+  }
+
+  void toStruct_INTEGER(const long long& _INTEGER_in, long long& INTEGER_out) {
     INTEGER_out = _INTEGER_in;
   }
   
   void toStruct_INTEGER(const long& _INTEGER_in, unsigned long& INTEGER_out) {
-    if (std::numeric_limits<unsigned long>::max() < _INTEGER_in) throw std::range_error("Failed to convert long to smaller unsigned long");
-    INTEGER_out = _INTEGER_in;
+    INTEGER_out = static_cast<unsigned long>(_INTEGER_in);
+  }
+
+  void toStruct_INTEGER(const long long& _INTEGER_in, unsigned long long& INTEGER_out) {
+    INTEGER_out = static_cast<unsigned long long>(_INTEGER_in);
   }
 }

--- a/etsi_its_rviz_plugins/CMakeLists.txt
+++ b/etsi_its_rviz_plugins/CMakeLists.txt
@@ -113,11 +113,8 @@ if(${ROS_VERSION} EQUAL 2)
 # === ROS (CATKIN) =============================================================
 elseif(${ROS_VERSION} EQUAL 1)
 
-  # Currently no support for ROS1!
-  # Specify that the directory should be excluded from the install target
-  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    DESTINATION .
-    EXCLUDE_FROM_ALL
-  )
+  find_package(catkin REQUIRED)
+
+  catkin_package()
 
 endif()

--- a/etsi_its_rviz_plugins/package.xml
+++ b/etsi_its_rviz_plugins/package.xml
@@ -40,7 +40,11 @@
   <exec_depend condition="$ROS_VERSION == 2">rviz_satellite</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">rviz2</exec_depend>
 
+  <!-- ROS -->
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+
   <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
     <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 


### PR DESCRIPTION
- make `etsi_its_rviz_plugins` a regular (dummy) ROS 1 package to fix ROS 1 pipeline failures
- fix `long` / `uint64_t` integer conversions for 32bit armhf architecture