### PR TITLE
Explicit toRos_INTEGER(const long&, int64_t&)

### DIFF
--- a/etsi_its_conversion/etsi_its_primitives_conversion/include/etsi_its_primitives_conversion/convertINTEGER.h
+++ b/etsi_its_conversion/etsi_its_primitives_conversion/include/etsi_its_primitives_conversion/convertINTEGER.h
@@ -54,6 +54,10 @@ namespace etsi_its_primitives_conversion {
     INTEGER_out = static_cast<T>(_INTEGER_in);
   }
 
+  void toRos_INTEGER(const long& _INTEGER_in, int64_t& INTEGER_out) {
+    INTEGER_out = _INTEGER_in;
+  }
+
   template <typename T>
   void toStruct_INTEGER(const int64_t& _INTEGER_in, T& INTEGER_out) {
     const long in = static_cast<long>(_INTEGER_in);


### PR DESCRIPTION
Calls to `toRos_INTEGER()` when `T` is `long`/`int64_t` are ambiguous due to two conflicting overloads:
```C++
void toRos_INTEGER(const T& _INTEGER_in, int64_t& INTEGER_out);
```
and
```C++
void toRos_INTEGER(const long& _INTEGER_in, T& INTEGER_out);
```

This PR simply adds an explicit `toRos_INTEGER()` overload for `(const long&, int64_t&)`.