### PR TITLE
Fix/offset

### DIFF
--- a/etsi_its_rviz_plugins/include/displays/DENM/denm_display.hpp
+++ b/etsi_its_rviz_plugins/include/displays/DENM/denm_display.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "etsi_its_cam_msgs/msg/cam.hpp"
 #include "etsi_its_denm_msgs/msg/denm.hpp"
 
 #include "displays/DENM/denm_render_object.hpp"
@@ -57,7 +56,7 @@ protected:
 
   // Properties
   rviz_common::properties::BoolProperty *show_meta_, *show_station_id_, *show_cause_code_, *show_sub_cause_code_;
-  rviz_common::properties::FloatProperty *buffer_timeout_, *bb_scale_, *char_height_;
+  rviz_common::properties::FloatProperty *buffer_timeout_, *char_height_;
   rviz_common::properties::ColorProperty *color_property_, *text_color_property_;
 
   std::unordered_map<int, DENMRenderObject> denms_;

--- a/etsi_its_rviz_plugins/include/displays/DENM/denm_render_object.hpp
+++ b/etsi_its_rviz_plugins/include/displays/DENM/denm_render_object.hpp
@@ -22,7 +22,7 @@ namespace displays
 class DENMRenderObject
 {
   public:
-    DENMRenderObject(etsi_its_denm_msgs::msg::DENM denm, rclcpp::Time receive_time, uint16_t n_leap_seconds=etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second);
+    DENMRenderObject(etsi_its_denm_msgs::msg::DENM denm, uint16_t n_leap_seconds=etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second);
 
     /**
      * @brief This function validates all float variables that are part of a DENMRenderObject

--- a/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
@@ -103,11 +103,10 @@ void CAMDisplay::processMessage(etsi_its_cam_msgs::msg::CAM::ConstSharedPtr msg)
   // Generate CAM render object from message
   rclcpp::Time now = rviz_node_->now();
   uint64_t nanosecs = now.nanoseconds();
-  if (nanosecs == 0)
-  {
+  if (nanosecs == 0) {
     setStatus(
-          rviz_common::properties::StatusProperty::Warn, "Topic",
-          "Message received before clock got a valid time");
+      rviz_common::properties::StatusProperty::Warn, "Topic",
+      "Message received before clock got a valid time");
     return;
   }
 

--- a/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
@@ -112,10 +112,10 @@ void CAMDisplay::processMessage(etsi_its_cam_msgs::msg::CAM::ConstSharedPtr msg)
 
   CAMRenderObject cam(*msg, now, getLeapSecondInsertionsSince2004(static_cast<uint64_t>(now.seconds())));
   if (!cam.validateFloats()) {
-        setStatus(
-          rviz_common::properties::StatusProperty::Error, "Topic",
-          "Message contained invalid floating point values (nans or infs)");
-        return;
+    setStatus(
+      rviz_common::properties::StatusProperty::Error, "Topic",
+      "Message contained invalid floating point values (nans or infs)");
+    return;
   }
 
   // Check if Station ID is already present in list
@@ -130,14 +130,14 @@ void CAMDisplay::update(float, float)
 {
   // Check for outdated CAMs
   for (auto it = cams_.begin(); it != cams_.end(); ) {
-        if (it->second.getAge(rviz_node_->now()) > buffer_timeout_->getFloat())
-        {
-          it = cams_.erase(it);
-        }
-        else
-        {
-          ++it;
-        }
+    if (it->second.getAge(rviz_node_->now()) > buffer_timeout_->getFloat())
+    {
+      it = cams_.erase(it);
+    }
+    else
+    {
+      ++it;
+    }
   }
 
   // Render all valid cams

--- a/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
@@ -100,7 +100,8 @@ void CAMDisplay::reset()
 void CAMDisplay::processMessage(etsi_its_cam_msgs::msg::CAM::ConstSharedPtr msg)
 {
   // Generate CAM render object from message
-  rclcpp::Time now = rviz_node_->now();
+  static rclcpp::Clock clock;
+  rclcpp::Time now = clock.now(); // Always use the current time for the render object, no sim time
   CAMRenderObject cam(*msg, now, getLeapSecondInsertionsSince2004((uint64_t)now.seconds()));
   if (!cam.validateFloats()) {
         setStatus(
@@ -119,10 +120,18 @@ void CAMDisplay::processMessage(etsi_its_cam_msgs::msg::CAM::ConstSharedPtr msg)
 
 void CAMDisplay::update(float, float)
 {
+  //RCLCPP_INFO_STREAM(rviz_node_->get_logger(), "Updating CAM display after " << wall_dt << " seconds, " << ros_dt << "seconds in ROS.");
   // Check for outdated CAMs
   for (auto it = cams_.begin(); it != cams_.end(); ) {
-        if (it->second.getAge(rviz_node_->now()) > buffer_timeout_->getFloat()) it = cams_.erase(it);
-        else ++it;
+        if (it->second.getAge(rviz_node_->now()) > buffer_timeout_->getFloat())
+        {
+          //RCLCPP_INFO_STREAM(rviz_node_->get_logger(), "Removing CAM with StationID " << it->first << " from display, age: " << it->second.getAge(rviz_node_->now()) << ".");
+          it = cams_.erase(it);
+        }
+        else
+        {
+          ++it;
+        }
   }
 
   // Render all valid cams
@@ -155,8 +164,14 @@ void CAMDisplay::update(float, float)
       // the reference point shall be the ground position of the centre of the front side of
       // the bounding box of the vehicle.
       // https://www.etsi.org/deliver/etsi_en/302600_302699/30263702/01.03.01_30/en_30263702v010301v.pdf
-      position.x-=dimensions.x/2.0;
-      position.z+=dimensions.z/2.0;
+      tf2::Quaternion q;
+      tf2::fromMsg(pose.orientation, q);
+      tf2::Matrix3x3 m(q);
+      tf2::Vector3 v(-dimensions.x/2.0, 0.0, dimensions.z/2.0);
+      v = m*v;
+      position.x += v.x();
+      position.y += v.y();
+      position.z += v.z();
     }
 
     // set pose of child scene node of bounding-box

--- a/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
@@ -24,49 +24,63 @@ SOFTWARE.
 
 #include "displays/CAM/cam_display.hpp"
 
-#include <OgreBillboardSet.h>
-#include <OgreManualObject.h>
-#include <OgreMaterialManager.h>
-#include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
+#include <OgreSceneManager.h>
+#include <OgreManualObject.h>
+#include <OgreBillboardSet.h>
+#include <OgreMaterialManager.h>
 #include <OgreTechnique.h>
 
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/logging.hpp"
-#include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/float_property.hpp"
+#include "rviz_common/properties/bool_property.hpp"
 
 #include "rviz_common/properties/parse_color.hpp"
 
-namespace etsi_its_msgs {
-namespace displays {
+namespace etsi_its_msgs
+{
+namespace displays
+{
 
-CAMDisplay::CAMDisplay() {
+CAMDisplay::CAMDisplay()
+{
   // General Properties
-  buffer_timeout_ =
-      new rviz_common::properties::FloatProperty("Timeout", 0.1f, "Time (in s) until objects disappear", this);
+  buffer_timeout_ = new rviz_common::properties::FloatProperty(
+    "Timeout", 0.1f,
+    "Time (in s) until objects disappear", this);
   buffer_timeout_->setMin(0);
-  bb_scale_ = new rviz_common::properties::FloatProperty("Scale", 1.0f, "Scale of objects", this);
+  bb_scale_ = new rviz_common::properties::FloatProperty(
+    "Scale", 1.0f,
+    "Scale of objects", this);
   bb_scale_->setMin(0.01);
-  color_property_ = new rviz_common::properties::ColorProperty("Color", QColor(25, 0, 255), "Object color", this);
-  show_meta_ =
-      new rviz_common::properties::BoolProperty("Metadata", true, "Show metadata as text next to objects", this);
-  text_color_property_ =
-      new rviz_common::properties::ColorProperty("Color", QColor(25, 0, 255), "Text color", show_meta_);
+  color_property_ = new rviz_common::properties::ColorProperty(
+    "Color", QColor(25, 0, 255),
+    "Object color", this);
+  show_meta_ = new rviz_common::properties::BoolProperty("Metadata", true,
+    "Show metadata as text next to objects", this);
+  text_color_property_ = new rviz_common::properties::ColorProperty(
+    "Color", QColor(25, 0, 255),
+    "Text color", show_meta_);
   char_height_ = new rviz_common::properties::FloatProperty("Scale", 4.0, "Scale of text", show_meta_);
-  show_station_id_ = new rviz_common::properties::BoolProperty("StationID", true, "Show StationID", show_meta_);
-  show_speed_ = new rviz_common::properties::BoolProperty("Speed", true, "Show speed", show_meta_);
+  show_station_id_ = new rviz_common::properties::BoolProperty("StationID", true,
+    "Show StationID", show_meta_);
+  show_speed_ = new rviz_common::properties::BoolProperty("Speed", true,
+    "Show speed", show_meta_);
+
 }
 
-CAMDisplay::~CAMDisplay() {
-  if (initialized()) {
+CAMDisplay::~CAMDisplay()
+{
+  if (initialized() ) {
     scene_manager_->destroyManualObject(manual_object_);
   }
 }
 
-void CAMDisplay::onInitialize() {
+void CAMDisplay::onInitialize()
+{
   RTDClass::onInitialize();
 
   auto nodeAbstraction = context_->getRosNodeAbstraction().lock();
@@ -77,49 +91,54 @@ void CAMDisplay::onInitialize() {
   scene_node_->attachObject(manual_object_);
 }
 
-void CAMDisplay::reset() {
+void CAMDisplay::reset()
+{
   RTDClass::reset();
   manual_object_->clear();
 }
 
-void CAMDisplay::processMessage(etsi_its_cam_msgs::msg::CAM::ConstSharedPtr msg) {
+void CAMDisplay::processMessage(etsi_its_cam_msgs::msg::CAM::ConstSharedPtr msg)
+{
   // Generate CAM render object from message
-  rclcpp::Time now =
-      rclcpp::Time(std::clamp<uint64_t>(rviz_node_->now().nanoseconds(), etsi_its_cam_msgs::msg::TimestampIts::MIN,
-                                        etsi_its_cam_msgs::msg::TimestampIts::MAX));
+  static rclcpp::Clock clock;
+  rclcpp::Time now = clock.now(); // Always use the current time for the render object, no sim time
   CAMRenderObject cam(*msg, now, getLeapSecondInsertionsSince2004((uint64_t)now.seconds()));
   if (!cam.validateFloats()) {
-    setStatus(rviz_common::properties::StatusProperty::Error, "Topic",
-              "Message contained invalid floating point values (nans or infs)");
-    return;
+        setStatus(
+          rviz_common::properties::StatusProperty::Error, "Topic",
+          "Message contained invalid floating point values (nans or infs)");
+        return;
   }
 
   // Check if Station ID is already present in list
   auto it = cams_.find(cam.getStationID());
-  if (it != cams_.end())
-    it->second = cam;  // Key exists, update the value
-  else
-    cams_.insert(std::make_pair(cam.getStationID(), cam));
+  if (it != cams_.end()) it->second = cam; // Key exists, update the value
+  else cams_.insert(std::make_pair(cam.getStationID(), cam));
 
   return;
 }
 
-void CAMDisplay::update(float, float) {
+void CAMDisplay::update(float, float)
+{
   //RCLCPP_INFO_STREAM(rviz_node_->get_logger(), "Updating CAM display after " << wall_dt << " seconds, " << ros_dt << "seconds in ROS.");
   // Check for outdated CAMs
-  for (auto it = cams_.begin(); it != cams_.end();) {
-    if (it->second.getAge(rviz_node_->now()) > buffer_timeout_->getFloat()) {
-      //RCLCPP_INFO_STREAM(rviz_node_->get_logger(), "Removing CAM with StationID " << it->first << " from display, age: " << it->second.getAge(rviz_node_->now()) << ".");
-      it = cams_.erase(it);
-    } else {
-      ++it;
-    }
+  for (auto it = cams_.begin(); it != cams_.end(); ) {
+        if (it->second.getAge(rviz_node_->now()) > buffer_timeout_->getFloat())
+        {
+          //RCLCPP_INFO_STREAM(rviz_node_->get_logger(), "Removing CAM with StationID " << it->first << " from display, age: " << it->second.getAge(rviz_node_->now()) << ".");
+          it = cams_.erase(it);
+        }
+        else
+        {
+          ++it;
+        }
   }
 
   // Render all valid cams
   bboxs_.clear();
   texts_.clear();
-  for (auto it = cams_.begin(); it != cams_.end(); ++it) {
+  for(auto it = cams_.begin(); it != cams_.end(); ++it) {
+
     CAMRenderObject cam = it->second;
     Ogre::Vector3 sn_position;
     Ogre::Quaternion sn_orientation;
@@ -139,7 +158,8 @@ void CAMDisplay::update(float, float) {
     geometry_msgs::msg::Vector3 dimensions = cam.getDimensions();
     Ogre::Vector3 position(pose.position.x, pose.position.y, pose.position.z);
     Ogre::Quaternion orientation(pose.orientation.w, pose.orientation.x, pose.orientation.y, pose.orientation.z);
-    if (3 <= cam.getStationType() && cam.getStationType() <= 11) {
+    if(3 <= cam.getStationType() && cam.getStationType() <= 11)
+    {
       // If the station type of the originating ITS-S is set to one out of the values 3 to 11
       // the reference point shall be the ground position of the centre of the front side of
       // the bounding box of the vehicle.
@@ -147,8 +167,8 @@ void CAMDisplay::update(float, float) {
       tf2::Quaternion q;
       tf2::fromMsg(pose.orientation, q);
       tf2::Matrix3x3 m(q);
-      tf2::Vector3 v(-dimensions.x / 2.0, 0.0, dimensions.z / 2.0);
-      v = m * v;
+      tf2::Vector3 v(-dimensions.x/2.0, 0.0, dimensions.z/2.0);
+      v = m*v;
       position.x += v.x();
       position.y += v.y();
       position.z += v.z();
@@ -159,15 +179,14 @@ void CAMDisplay::update(float, float) {
     child_scene_node->setOrientation(orientation);
 
     // create boundind-box object
-    std::shared_ptr<rviz_rendering::Shape> bbox =
-        std::make_shared<rviz_rendering::Shape>(rviz_rendering::Shape::Cube, scene_manager_, child_scene_node);
+    std::shared_ptr<rviz_rendering::Shape> bbox = std::make_shared<rviz_rendering::Shape>(rviz_rendering::Shape::Cube, scene_manager_, child_scene_node);
 
     // set the dimensions of bounding box
     Ogre::Vector3 dims;
     double scale = bb_scale_->getFloat();
-    dims.x = dimensions.x * scale;
-    dims.y = dimensions.y * scale;
-    dims.z = dimensions.z * scale;
+    dims.x = dimensions.x*scale;
+    dims.y = dimensions.y*scale;
+    dims.z = dimensions.z*scale;
     bbox->setScale(dims);
     // set the color of bounding box
     Ogre::ColourValue bb_color = rviz_common::properties::qtToOgre(color_property_->getColor());
@@ -175,20 +194,19 @@ void CAMDisplay::update(float, float) {
     bboxs_.push_back(bbox);
 
     // Visualize meta-information as text
-    if (show_meta_->getBool()) {
+    if(show_meta_->getBool()) {
       std::string text;
-      if (show_station_id_->getBool()) {
-        text += "StationID: " + std::to_string(cam.getStationID());
-        text += "\n";
+      if(show_station_id_->getBool()) {
+        text+="StationID: " + std::to_string(cam.getStationID());
+        text+="\n";
       }
-      if (show_speed_->getBool()) {
-        text += "Speed: " + std::to_string((int)(cam.getSpeed() * 3.6)) + " km/h";
+      if(show_speed_->getBool()) {
+        text+="Speed: " + std::to_string((int)(cam.getSpeed()*3.6)) + " km/h";
       }
-      if (!text.size()) return;
-      std::shared_ptr<rviz_rendering::MovableText> text_render =
-          std::make_shared<rviz_rendering::MovableText>(text, "Liberation Sans", char_height_->getFloat());
+      if(!text.size()) return;
+      std::shared_ptr<rviz_rendering::MovableText> text_render = std::make_shared<rviz_rendering::MovableText>(text, "Liberation Sans", char_height_->getFloat());
       double height = dims.z;
-      height += text_render->getBoundingRadius();
+      height+=text_render->getBoundingRadius();
       Ogre::Vector3 offs(0.0, 0.0, height);
       // There is a bug in rviz_rendering::MovableText::setGlobalTranslation https://github.com/ros2/rviz/issues/974
       text_render->setGlobalTranslation(offs);

--- a/etsi_its_rviz_plugins/src/displays/DENM/denm_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/DENM/denm_display.cpp
@@ -28,10 +28,6 @@ DENMDisplay::DENMDisplay()
     "Timeout", 0.1f,
     "Time (in s) until visualizations disappear", this);
   buffer_timeout_->setMin(0);
-  bb_scale_ = new rviz_common::properties::FloatProperty(
-    "Scale", 1.0f,
-    "Scale of visualization", this);
-  bb_scale_->setMin(0.01);
   color_property_ = new rviz_common::properties::ColorProperty(
     "Color", QColor(255, 0, 25),
     "Color", this);
@@ -139,8 +135,6 @@ void DENMDisplay::update(float, float)
     // create arrow object
     std::shared_ptr<rviz_rendering::Arrow> arrow = std::make_shared<rviz_rendering::Arrow>(scene_manager_, child_scene_node, shaft_length, shaft_diameter, head_length, head_diameter);
     
-    // set the dimensions of arrow
-    double scale = bb_scale_->getFloat();
     // set the color of arrow
     Ogre::ColourValue bb_color = rviz_common::properties::qtToOgre(color_property_->getColor());
     arrow->setColor(bb_color);

--- a/etsi_its_rviz_plugins/src/displays/DENM/denm_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/DENM/denm_display.cpp
@@ -72,7 +72,7 @@ void DENMDisplay::processMessage(etsi_its_denm_msgs::msg::DENM::ConstSharedPtr m
 {
   // Generate DENM render object from message
   rclcpp::Time now = rviz_node_->now();
-  DENMRenderObject denm(*msg, now, getLeapSecondInsertionsSince2004((uint64_t)now.seconds())); // 5 leap seconds in 2023
+  DENMRenderObject denm(*msg, getLeapSecondInsertionsSince2004((uint64_t)now.seconds())); // 5 leap seconds in 2023
   if (!denm.validateFloats()) {
         setStatus(
           rviz_common::properties::StatusProperty::Error, "Topic",

--- a/etsi_its_rviz_plugins/src/displays/DENM/denm_render_object.cpp
+++ b/etsi_its_rviz_plugins/src/displays/DENM/denm_render_object.cpp
@@ -5,7 +5,7 @@ namespace etsi_its_msgs
 namespace displays
 {
 
-  DENMRenderObject::DENMRenderObject(etsi_its_denm_msgs::msg::DENM denm, rclcpp::Time receive_time, uint16_t n_leap_seconds) {
+  DENMRenderObject::DENMRenderObject(etsi_its_denm_msgs::msg::DENM denm, uint16_t n_leap_seconds) {
 
     int zone;
     bool northp;
@@ -20,10 +20,10 @@ namespace displays
     sub_cause_code_type = etsi_its_denm_msgs::access::getSubCauseCodeType(denm);
     
     double heading; // 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West
-    if(etsi_its_denm_msgs::access::getIsHeadingPresent(denm)){
+    if(etsi_its_denm_msgs::access::getIsHeadingPresent(denm)) {
       heading = (90-etsi_its_denm_msgs::access::getHeading(denm))*M_PI/180.0;
     }
-    else{
+    else {
       heading = 0*M_PI/180.0;
     }
     while(heading<0) heading+=2*M_PI;
@@ -32,10 +32,10 @@ namespace displays
     orientation.setRPY(0.0, 0.0, heading);
     pose.orientation = tf2::toMsg(orientation);
 
-    if(etsi_its_denm_msgs::access::getIsSpeedPresent(denm)){
+    if(etsi_its_denm_msgs::access::getIsSpeedPresent(denm)) {
       speed = etsi_its_denm_msgs::access::getSpeed(denm);
     }
-    else{
+    else {
       speed = 0;
     }
   }
@@ -67,11 +67,11 @@ namespace displays
   return speed;
   }
 
-  std::string DENMRenderObject::getCauseCode(){
+  std::string DENMRenderObject::getCauseCode() {
     return cause_code_type;
   }
 
-  std::string DENMRenderObject::getSubCauseCode(){
+  std::string DENMRenderObject::getSubCauseCode() {
     return sub_cause_code_type;
   }
 


### PR DESCRIPTION
Three changes:

1. Most classes in ETSI have their reference position at the front of the vehicle. The RVIZ display did account for that, but assumed, that the transformation to the center is just `(-length/2, 0, height/2)`. The mistake was that we are not applying this transform inside the vehicle's frame (`child_scene_node`), but we are _setting_ this node. So we need to apply its rotation to the transformation.
2. The ETSI messages come in a frame like `UTM_32N` and have thus huge numbers inside the position fields. As RVIZ internally renders stuff using OGRE, which (by default) only uses single precision floats, these tend to flicker a lot due to rounding errors. If the UTM frame is our fixed frame, there's nothing we can do about this (except from building OGRE from source with double precision by setting `OGRE_DOUBLE_PRECISION` in `OgreConfig.h` to `1`, but this would then require to build RVIZ from source, which we might want to do in future, but not in this MR). But if the fixed frame is a `map` frame somewhere near the ETSI messages, we can first compute all the transformations in tf, which uses double precision, and then give the resulting (small) numbers to OGRE w/o loss of precision.
3. Minor refactoring in DENM plugin, mainly to supress compile-warnings.

(Minor change: If sim time is used, but the time source (e.g. rosbag) sends first a CAM and then a clock message, the first CAM is now discarded by checking for `current_time==0`)

Screenshot showing the old plugin: (CAM in blue vs ground truth position in red)
![grafik](https://github.com/ika-rwth-aachen/etsi_its_messages/assets/56032277/e0d0d102-8acd-4eaa-85e3-865b5de3e50f)

and with this fix:
![grafik](https://github.com/ika-rwth-aachen/etsi_its_messages/assets/56032277/fece9b06-a8a6-47e6-b724-e46da4967e93)
