### PR TITLE
Use `rwthika/ros2:jazzy` base image in CI

### DIFF
--- a/.github/workflows/docker-ros.yml
+++ b/.github/workflows/docker-ros.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           platform: amd64
           target: dev,run
-          image-tag: ros2
+          image-tag: ros2-humble
           base-image: rwthika/ros2:humble
           command: ros2 launch etsi_its_conversion converter.launch.py
           enable-industrial-ci: 'true'
@@ -51,9 +51,8 @@ jobs:
           platform: amd64
           target: dev,run
           image-tag: ros2-jazzy
-          base-image: ubuntu:24.04
-          ros-distro: jazzy
+          enable-push-as-latest: 'true'
+          base-image: rwthika/ros2:jazzy
           command: ros2 launch etsi_its_conversion converter.launch.py
           enable-industrial-ci: 'true'
-          enable-push-as-latest: 'true'
           enable-recursive-vcs-import: 'false'

--- a/.github/workflows/docker-ros.yml
+++ b/.github/workflows/docker-ros.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           platform: amd64
           target: dev,run
-          image-tag: ros
+          image-tag: ros-noetic
           base-image: rwthika/ros:noetic
           command: roslaunch etsi_its_conversion converter.ros1.launch
           enable-industrial-ci: 'true'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ ros2-humble:
   variables:
     PLATFORM: amd64,arm64
     TARGET: dev,run
-    IMAGE_TAG: ros2
+    IMAGE_TAG: ros2-humble
     BASE_IMAGE: rwthika/ros2:humble
     COMMAND: ros2 launch etsi_its_conversion converter.launch.py
     ENABLE_INDUSTRIAL_CI: 'true'
@@ -56,10 +56,8 @@ ros2-jazzy:
     PLATFORM: amd64,arm64
     TARGET: dev,run
     IMAGE_TAG: ros2-jazzy
-    # TODO: switch to rwthika/ros2:jazzy, once available
-    BASE_IMAGE: ubuntu:24.04
-    ROS_DISTRO: jazzy
+    ENABLE_PUSH_AS_LATEST: 'true'
+    BASE_IMAGE: rwthika/ros2:jazzy
     COMMAND: ros2 launch etsi_its_conversion converter.launch.py
     ENABLE_INDUSTRIAL_CI: 'true'
-    ENABLE_PUSH_AS_LATEST: 'true'
     ENABLE_RECURSIVE_VCS_IMPORT: 'false'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ ros-noetic:
   variables:
     PLATFORM: amd64,arm64
     TARGET: dev,run
-    IMAGE_TAG: ros1
+    IMAGE_TAG: ros-noetic
     BASE_IMAGE: rwthika/ros:noetic
     COMMAND: roslaunch etsi_its_conversion converter.ros1.launch
     ENABLE_INDUSTRIAL_CI: 'true'

--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ catkin build -DCMAKE_BUILD_TYPE=Release etsi_its_messages
 The *etsi_its_messages* package stack is also available as a Docker image, containerized through [*docker-ros*](https://github.com/ika-rwth-aachen/docker-ros). Note that launching these containers starts the `etsi_its_conversion` node by default.
 
 ```bash
-# ROS 2 (jazzy)
-docker run --rm ghcr.io/ika-rwth-aachen/etsi_its_messages:latest
+# ROS 2
+docker run --rm ghcr.io/ika-rwth-aachen/etsi_its_messages:ros2-jazzy
 
-# ROS (noetic)
-docker run --rm ghcr.io/ika-rwth-aachen/etsi_its_messages:ros
+# ROS
+docker run --rm ghcr.io/ika-rwth-aachen/etsi_its_messages:ros-noetic
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The *etsi_its_messages* package stack is also available as a Docker image, conta
 
 ```bash
 # ROS 2 (jazzy)
-docker run --rm ghcr.io/ika-rwth-aachen/etsi_its_messages:ros2
+docker run --rm ghcr.io/ika-rwth-aachen/etsi_its_messages:latest
 
 # ROS (noetic)
 docker run --rm ghcr.io/ika-rwth-aachen/etsi_its_messages:ros


### PR DESCRIPTION
Since our base image `rwthika/ros2:jazzy` is available now, we no longer have to resort to `ubuntu:24.04`.

Additionally, no more image is tagged `ros2`. All variants are tagged, e.g., `ros2-jazzy`, with `ros2-jazzy` also being tagged as `latest`.