### PR TITLE
Fix V2AIX reference in table of contents of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ All message definitions and conversion functions are automatically generated bas
 - [Conversion Node](#conversion-node)
 - [Access Functions](#access-functions)
 - [Code Generation](#code-generation)
-- [V2AIX Dataset / Citation](#v2aix-dataset-citation)
+- [V2AIX Dataset / Citation](#v2aix-dataset--citation)
 - [Acknowledgements](#acknowledgements)
 - [Notice](#notice)
 


### PR DESCRIPTION
Fixes the quick reference link to the V2AIX section in the readme