### PR TITLE
Fix access of optional members with 0 as default value in conversion functions

### DIFF
--- a/etsi_its_conversion/etsi_its_cam_ts_conversion/include/etsi_its_cam_ts_conversion/convertLanePositionAndType.h
+++ b/etsi_its_conversion/etsi_its_cam_ts_conversion/include/etsi_its_cam_ts_conversion/convertLanePositionAndType.h
@@ -44,22 +44,16 @@ namespace etsi_its_cam_ts_conversion {
 
 void toRos_LanePositionAndType(const cam_ts_LanePositionAndType_t& in, cam_ts_msgs::LanePositionAndType& out) {
   toRos_LanePosition(in.transversalPosition, out.transversal_position);
-  if (in.laneType) {
-    toRos_LaneType(*in.laneType, out.lane_type);
-  }
-  if (in.direction) {
-    toRos_Direction(*in.direction, out.direction);
-  }
+  toRos_LaneType(in.laneType, out.lane_type);
+  toRos_Direction(in.direction, out.direction);
 }
 
 void toStruct_LanePositionAndType(const cam_ts_msgs::LanePositionAndType& in, cam_ts_LanePositionAndType_t& out) {
   memset(&out, 0, sizeof(cam_ts_LanePositionAndType_t));
 
   toStruct_LanePosition(in.transversal_position, out.transversalPosition);
-  out.laneType = (cam_ts_LaneType_t*) calloc(1, sizeof(cam_ts_LaneType_t));
-  toStruct_LaneType(in.lane_type, *out.laneType);
-  out.direction = (cam_ts_Direction_t*) calloc(1, sizeof(cam_ts_Direction_t));
-  toStruct_Direction(in.direction, *out.direction);
+  toStruct_LaneType(in.lane_type, out.laneType);
+  toStruct_Direction(in.direction, out.direction);
 }
 
 }

--- a/etsi_its_conversion/etsi_its_cam_ts_conversion/include/etsi_its_cam_ts_conversion/convertLanePositionWithLateralDetails.h
+++ b/etsi_its_conversion/etsi_its_cam_ts_conversion/include/etsi_its_cam_ts_conversion/convertLanePositionWithLateralDetails.h
@@ -47,12 +47,8 @@ void toRos_LanePositionWithLateralDetails(const cam_ts_LanePositionWithLateralDe
   toRos_StandardLength9b(in.distanceToLeftBorder, out.distance_to_left_border);
   toRos_StandardLength9b(in.distanceToRightBorder, out.distance_to_right_border);
   toRos_LanePosition(in.transversalPosition, out.transversal_position);
-  if (in.laneType) {
-    toRos_LaneType(*in.laneType, out.lane_type);
-  }
-  if (in.direction) {
-    toRos_Direction(*in.direction, out.direction);
-  }
+  toRos_LaneType(in.laneType, out.lane_type);
+  toRos_Direction(in.direction, out.direction);
 }
 
 void toStruct_LanePositionWithLateralDetails(const cam_ts_msgs::LanePositionWithLateralDetails& in, cam_ts_LanePositionWithLateralDetails_t& out) {
@@ -61,10 +57,8 @@ void toStruct_LanePositionWithLateralDetails(const cam_ts_msgs::LanePositionWith
   toStruct_StandardLength9b(in.distance_to_left_border, out.distanceToLeftBorder);
   toStruct_StandardLength9b(in.distance_to_right_border, out.distanceToRightBorder);
   toStruct_LanePosition(in.transversal_position, out.transversalPosition);
-  out.laneType = (cam_ts_LaneType_t*) calloc(1, sizeof(cam_ts_LaneType_t));
-  toStruct_LaneType(in.lane_type, *out.laneType);
-  out.direction = (cam_ts_Direction_t*) calloc(1, sizeof(cam_ts_Direction_t));
-  toStruct_Direction(in.direction, *out.direction);
+  toStruct_LaneType(in.lane_type, out.laneType);
+  toStruct_Direction(in.direction, out.direction);
 }
 
 }

--- a/utils/codegen/codegen-rust/rgen/src/conversion/utils.rs
+++ b/utils/codegen/codegen-rust/rgen/src/conversion/utils.rs
@@ -124,7 +124,7 @@ impl Conversion {
                         is_primitive: member.ty.is_builtin_type(),
                         inner_types: self.get_inner_types_names(&member.ty),
                 },
-                is_optional: member.is_optional,
+                is_optional: member.is_optional && (member.default_value.is_none() || self.value_to_tokens(member.default_value.as_ref().unwrap(), None).unwrap() != "0"),
                 has_default: member.default_value.is_some(),
             })
         .collect::<Vec<NamedSeqMember>>()


### PR DESCRIPTION
- only interpret optional member as a pointer if default is not 0
- currently has no effect, as this only occurs with one element of the CAM TS, which is not used by the CAM TS