### PR TITLE
Deprecate ROS 2 Iron support as it's EOL

### DIFF
--- a/.github/workflows/bloom-release.yml
+++ b/.github/workflows/bloom-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Release ROS 2
         uses: at-wat/bloom-release-action@v0
         with:
-          ros_distro: humble iron jazzy
+          ros_distro: humble jazzy
           github_token_bloom: ${{ secrets.GH_TOKEN_FOR_BLOOM_RELEASE }}
           github_user: jpbusch
           git_user: Jean-Pierre Busch

--- a/.github/workflows/docker-ros.yml
+++ b/.github/workflows/docker-ros.yml
@@ -30,19 +30,6 @@ jobs:
           enable-industrial-ci: 'true'
           enable-recursive-vcs-import: 'false'
 
-  ros2-iron:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ika-rwth-aachen/docker-ros@main
-        with:
-          platform: amd64
-          target: dev,run
-          image-tag: ros2-iron
-          base-image: rwthika/ros2:iron
-          command: ros2 launch etsi_its_conversion converter.launch.py
-          enable-industrial-ci: 'true'
-          enable-recursive-vcs-import: 'false'
-
   ros2-jazzy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -11,7 +11,6 @@ jobs:
         ROS_DISTRO:
           - noetic
           - humble
-          - iron
           - jazzy
         ROS_REPO:
           - testing

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,20 +33,6 @@ ros2-humble:
     ENABLE_INDUSTRIAL_CI: 'true'
     ENABLE_RECURSIVE_VCS_IMPORT: 'false'
 
-ros2-iron:
-  trigger:
-    include:
-      - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/main/.gitlab-ci/docker-ros.yml
-    strategy: depend
-  variables:
-    PLATFORM: amd64,arm64
-    TARGET: dev,run
-    IMAGE_TAG: ros2-iron
-    BASE_IMAGE: rwthika/ros2:iron
-    COMMAND: ros2 launch etsi_its_conversion converter.launch.py
-    ENABLE_INDUSTRIAL_CI: 'true'
-    ENABLE_RECURSIVE_VCS_IMPORT: 'false'
-
 ros2-jazzy:
   trigger:
     include:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/docker-ros.yml"><img src="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/docker-ros.yml/badge.svg"/></a>
   <a href="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/doc.yml"><img src="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/doc.yml/badge.svg"/></a>
   <img src="https://img.shields.io/badge/ROS-noetic-blueviolet"/>
-  <img src="https://img.shields.io/badge/ROS 2-humble|iron|jazzy-blueviolet"/>
+  <img src="https://img.shields.io/badge/ROS 2-humble|jazzy-blueviolet"/>
   <img src="https://img.shields.io/badge/V2X-CAM|CPM|DENM|MAPEM|SPATEM|VAM-aqua"/>
 </p>
 


### PR DESCRIPTION
- [ROS 2 Iron has been marked end-of-life (EOL) as of November 2024](https://discourse.ros.org/t/iron-irwini-eol-plan/40365)
- this PR removes support for ROS 2 Iron