### PR TITLE
Automatically set latest release-tag as project-number for doxygen documentation

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - improvement/latest-release-tag-for-doxygen
 
 jobs:
   build:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -6,6 +6,7 @@ on:
       - main
       - improvement/latest-release-tag-for-doxygen
 
+jobs:
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           submodules: true
       - name: Get latest release tag
-        uses: actions-ecosytem/action-get-latest-tag@v1
+        uses: actions-ecosystem/action-get-latest-tag@v1
         with:
           semver_only: true
         id: get-latest-tag

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - main
+      - improvement/latest-release-tag-for-doxygen
 
-jobs:
   build:
     runs-on: ubuntu-latest
     steps:
@@ -13,6 +13,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Get latest release tag
+        uses: actions-ecosytem/action-get-latest-tag@v1
+        with:
+          semver_only: true
+        id: get-latest-tag
+      - name: Export DOXYGEN_PROJECT_NUMBER
+        run: echo "DOXYGEN_PROJECT_NUMBER=${{ steps.get-latest-tag.outputs.tag }}" >> $GITHUB_ENV
       - name: Run Doxygen
         uses: mattnotmitt/doxygen-action@v1.1.0
         with:

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -5,7 +5,7 @@
 #---------------------------------------------------------------------------
 # DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "etsi_its_messages"
-PROJECT_NUMBER         = 2.4.0
+PROJECT_NUMBER         = $(DOXYGEN_PROJECT_NUMBER)
 # PROJECT_BRIEF          =
 # PROJECT_LOGO           =
 # OUTPUT_DIRECTORY       =


### PR DESCRIPTION
# Automatically set latest release-tag as project-number for doxygen documentation
With this PR the project-number of the [doxygen-documentation](https://ika-rwth-aachen.github.io/etsi_its_messages/) is set according to the latest release-tag.

This requires the following changes:
- `PROJECT_NUMBER` in doxyfile is set by an environment-variable named `DOXYGEN_PROJECT_NUMBER`
- doc-workflow is adapted to set the `DOXYGEN_PROJECT_NUMBER` before running doxygen