### PR TITLE
Fix example for access-functions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,11 +247,11 @@ The `etsi_its_msgs_utils` package contains header-only libraries providing helpf
 
 // ...
 
-double speed;
+double speed = 10.0; // vehicle speed in m/s
 etsi_its_cam_msgs::msg::CAM cam;
-etsi_its_cam_msgs::access::setSpeed(cam, 10.0);
+etsi_its_cam_msgs::access::setSpeed(cam, speed);
 // instead of
-cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.speed.speed_value.value = 10.0;
+cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.speed.speed_value.value = (uint16_t)(speed * 1e2);
 
 // ...
 ```

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
@@ -114,7 +114,7 @@ inline void setAltitude(Altitude& altitude, const double value) {
  * @param value SpeedValue in m/s as decimal number
  */
 inline void setSpeedValue(SpeedValue& speed, const double value) {
-  int64_t speed_val = (int64_t)std::round(value * 1e2);
+  uint16_t speed_val = (uint16_t)std::round(value * 1e2);
   throwIfOutOfRange(speed_val, SpeedValue::MIN, SpeedValue::MAX, "SpeedValue");
   speed.value = speed_val;
 }


### PR DESCRIPTION
# Fix example for access-functions in README

The naive example of setting a `SpeedValue` of a CAM was not correct, since it should be given in cm/s while the access function allows us to set the Value in m/s.

Additionally adapted the datatype to `uint16_t` accordingly.