### PR TITLE
Build jazzy docker images with rmw_zenoh support  

### DIFF
--- a/.github/workflows/docker-ros.yml
+++ b/.github/workflows/docker-ros.yml
@@ -40,6 +40,7 @@ jobs:
           image-tag: ros2-jazzy
           enable-push-as-latest: 'true'
           base-image: rwthika/ros2:jazzy
+          rmw-implementation: rmw_zenoh_cpp
           command: ros2 launch etsi_its_conversion converter.launch.py
           enable-industrial-ci: 'true'
           enable-recursive-vcs-import: 'false'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,7 @@ ros2-jazzy:
     IMAGE_TAG: ros2-jazzy
     ENABLE_PUSH_AS_LATEST: 'true'
     BASE_IMAGE: rwthika/ros2:jazzy
+    RMW_IMPLEMENTATION: rmw_zenoh_cpp
     COMMAND: ros2 launch etsi_its_conversion converter.launch.py
     ENABLE_INDUSTRIAL_CI: 'true'
     ENABLE_RECURSIVE_VCS_IMPORT: 'false'


### PR DESCRIPTION
- add docker-ros flag for rmw_zenoh support to GitHub and GitLab CI