### PR TITLE
Improvement/display spatem timing information

### DIFF
--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
@@ -37,6 +37,13 @@ namespace etsi_its_spatem_ts_msgs {
 
 namespace access {
 
+  const std::array<float, 4> color_grey {0.5, 0.5, 0.5, 1.0};
+  const std::array<float, 4> color_green {0.18, 0.79, 0.21, 1.0};
+  const std::array<float, 4> color_orange {0.9, 0.7, 0.09, 1.0};
+  const std::array<float, 4> color_red {0.8, 0.2, 0.2, 1.0};
+
+  enum time_mark_value_interpretation { normal, undefined, over_an_hour, leap_second };
+
   /**
    * @brief Get the unix seconds of the beginning of a year that corresponds to a given unix timestamp
    * 
@@ -71,6 +78,205 @@ namespace access {
   inline uint64_t getUnixNanosecondsFromMinuteOfTheYear(const MinuteOfTheYear& moy, const uint64_t unix_nanoseconds_estimate) {
     return ((uint64_t)(moy.value*60) + getUnixSecondsOfYear(unix_nanoseconds_estimate*1e-9))*1e9;
   }
+
+  /**
+   * @brief Interprets the TimeIntervalConfidence type as a percent value (see etsi definition)
+   * 
+   * @param encoded_probability Value from msg type TimeIntervalConfidence
+   * @return float percentage value [0, 1]
+   */
+  inline float interpretTimeIntervalConfidenceAsPercent(const uint16_t encoded_probability) {
+    float probability = 0;
+
+    switch (encoded_probability)
+    {
+      case 0:
+        probability = 0.21;
+        break;
+      case 1:
+        probability = 0.36;
+        break;
+      case 2: 
+        probability = 0.47;
+        break;
+      case 3:
+        probability = 0.56;
+        break;
+      case 4:
+        probability = 0.62;
+        break;
+      case 5: 
+        probability = 0.68;
+        break;
+      case 6:
+        probability = 0.73;
+        break;
+      case 7:
+        probability = 0.77;
+        break;
+      case 8:
+        probability = 0.81;
+        break;
+      case 9:
+        probability = 0.85;
+        break;
+      case 10:
+        probability = 0.88;
+        break;
+      case 11:
+        probability = 0.91;
+        break;
+      case 12:
+        probability = 0.94;
+        break;
+      case 13:
+        probability = 0.96;
+        break;
+      case 14:
+        probability = 0.98;
+        break; 
+      case 15:
+        probability = 1.0;
+        break;
+    }
+
+    return probability;
+  }
+
+  /**
+   * @brief Interprets the MovementStatePhase type as a color (see etsi definition)
+   * 
+   * @param value Encoded color value from msg type TimeIntervalConfidence
+   * @return 4-dimensional array with color values as follows: r, g, b, a, each of these values within a range between [0, 1]
+   */
+  inline std::array<float, 4> interpretMovementStatePhaseAsColor(const uint8_t value)
+  {
+    std::array<float, 4> color;
+
+    switch (value) {
+
+      case etsi_its_spatem_ts_msgs::msg::MovementPhaseState::UNAVAILABLE:
+        color = color_grey;
+        break;
+
+      case etsi_its_spatem_ts_msgs::msg::MovementPhaseState::DARK:
+        color = color_grey;
+        break;
+      case etsi_its_spatem_ts_msgs::msg::MovementPhaseState::STOP_THEN_PROCEED:
+        color = color_red;
+        break;
+      case etsi_its_spatem_ts_msgs::msg::MovementPhaseState::STOP_AND_REMAIN:
+        color = color_red;
+        break;
+      case etsi_its_spatem_ts_msgs::msg::MovementPhaseState::PRE_MOVEMENT:
+        color = color_orange;
+        break;
+      case etsi_its_spatem_ts_msgs::msg::MovementPhaseState::PERMISSIVE_MOVEMENT_ALLOWED:
+        color = color_green;
+        break;
+      case etsi_its_spatem_ts_msgs::msg::MovementPhaseState::PROTECTED_MOVEMENT_ALLOWED:
+        color = color_green;
+        break;
+      case etsi_its_spatem_ts_msgs::msg::MovementPhaseState::PERMISSIVE_CLEARANCE:
+        color = color_orange;
+        break;
+      case etsi_its_spatem_ts_msgs::msg::MovementPhaseState::PROTECTED_CLEARANCE:
+        color = color_orange;
+        break;
+      case etsi_its_spatem_ts_msgs::msg::MovementPhaseState::CAUTION_CONFLICTING_TRAFFIC:
+        color = color_orange;
+        break;
+      default:
+        color = color_grey;
+        break;
+  }
+
+  return color;
+}
+
+
+// Converts a value from message type "TimeMarkValue" into a string representation
+// time: time in 0.1 seconds until the next change occours in the future
+// header: time stamped message header which suits as an absolute time reference
+
+/**
+ * @brief Interprets the type of a TimeMark message
+ * See etsi ASNI1 - IS TS 103 301 documentation for for the encoding of "TimeMark"
+ * @param time The value inside the TimeMark message
+ * @return Type as time_mark_value_interpretation 
+ */
+time_mark_value_interpretation interpretTimeMarkValueType(const uint16_t time) {
+  time_mark_value_interpretation type;
+
+  if (time == 36001) {
+    // value is undefined or unknown
+    type = time_mark_value_interpretation::undefined;
+  } else if (time == 36000) {
+    // used to indicate time >3600 seconds
+    type = time_mark_value_interpretation::over_an_hour;
+  } else if (time >= 35991 && time <= 35999) {
+    // leap second
+    type = time_mark_value_interpretation::leap_second;
+  } else { // time >= 0 && time <= 36000
+    type = time_mark_value_interpretation::normal;
+  }
+
+  return type;
+}
+
+/**
+ * @brief Calculate the amount of seconds until the given time is reached
+ * 
+ * @param time Encoded time value in the future
+ * @param seconds Elapsed seconds since the start of the last full hour (timestamp)
+ * @param nanosec Elapsed nanoseconds since the start of the last full hour (timestamp)
+ * @return Time in seconds refered to the given timestamp
+ */
+float interpretTimeMarkValueAsSeconds(const uint16_t time, const int32_t seconds, const uint32_t nanosec) {
+  // calculate elapsed seconds since the start of the last full hour  
+  float abs_time_hour = ((int)(seconds)) % 3600 + (float)nanosec * 1e-9;
+  float rel_time_until_change = (float)time * 0.1f - abs_time_hour;
+            
+  return rel_time_until_change;
+}
+
+/**
+ * @brief Converts a value from message type TimeMarkValue into a string representation
+ * 
+ * @param time Time in 0.1 seconds until the next change occours in the future, counting from the last started hour
+ * @param seconds Elapsed seconds since the start of the last full hour (timestamp)
+ * @param nanosec Elapsed nanoseconds since the start of the last full hour (timestamp)
+ * @return Decoded String representation of the encoded time
+ */
+std::string parseTimeMarkValueToString(const uint16_t time, const int32_t seconds, const uint32_t nanosec)
+{
+  time_mark_value_interpretation time_type = interpretTimeMarkValueType(time);
+
+  std::string text_content;
+
+  switch (time_type) {
+    case time_mark_value_interpretation::undefined:
+      text_content = "undefined";
+      break;
+    case time_mark_value_interpretation::over_an_hour:
+      text_content = ">36000s";
+      break;
+    case time_mark_value_interpretation::leap_second:
+      text_content = "leap second";
+      break;
+    case time_mark_value_interpretation::normal:
+      float rel_time_until_change = interpretTimeMarkValueAsSeconds(time, seconds, nanosec);
+
+      // set displayed precision to 0.1
+      std::stringstream ss;
+      ss << std::fixed << std::setprecision(1) << rel_time_until_change << "s";
+      text_content = ss.str();
+      break;
+  }
+
+  return text_content;
+}
+
 
 } // namespace etsi_its_spatem_ts_msgs
 } // namespace access

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
@@ -80,12 +80,12 @@ namespace access {
   }
 
   /**
-   * @brief Interprets the TimeIntervalConfidence type as a percent value (see etsi definition)
+   * @brief Interprets the TimeIntervalConfidence type as a float value (see etsi definition)
    * 
    * @param encoded_probability Value from msg type TimeIntervalConfidence
-   * @return float percentage value [0, 1]
+   * @return confidence as float value [0, 1]
    */
-  inline float interpretTimeIntervalConfidenceAsPercent(const uint16_t encoded_probability) {
+  inline float interpretTimeIntervalConfidenceAsFloat(const uint16_t encoded_probability) {
     float probability = 0;
 
     switch (encoded_probability)
@@ -144,12 +144,12 @@ namespace access {
   }
 
   /**
-   * @brief Interprets the MovementStatePhase type as a color (see etsi definition)
+   * @brief Interprets the MovementPhaseState type as a color (see etsi definition)
    * 
-   * @param value Encoded color value from msg type TimeIntervalConfidence
+   * @param value Encoded color value from msg type MovementPhaseState
    * @return 4-dimensional array with color values as follows: r, g, b, a, each of these values within a range between [0, 1]
    */
-  inline std::array<float, 4> interpretMovementStatePhaseAsColor(const uint8_t value)
+  inline std::array<float, 4> interpretMovementPhaseStateAsColor(const uint8_t value)
   {
     std::array<float, 4> color;
 

--- a/etsi_its_rviz_plugins/include/displays/MAPEM/intersection_render_object.hpp
+++ b/etsi_its_rviz_plugins/include/displays/MAPEM/intersection_render_object.hpp
@@ -53,6 +53,8 @@ typedef struct IntersectionMovementState {
   std_msgs::msg::Header header;
   uint8_t signal_group_id;
   etsi_its_spatem_ts_msgs::msg::MovementPhaseState phase_state;
+  etsi_its_spatem_ts_msgs::msg::TimeChangeDetails::SharedPtr time_change_details;
+
 } IntersectionMovementState;
 
 /**

--- a/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
+++ b/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
@@ -97,7 +97,7 @@ protected:
   rclcpp::QoS spatem_qos_profile_ = rclcpp::QoS(1);
 
   // Properties
-  rviz_common::properties::BoolProperty *show_meta_spatem_, *show_meta_mapem_, *viz_spatem_, *viz_mapem_, *show_spatem_;
+  rviz_common::properties::BoolProperty *show_meta_spatem_, *show_meta_mapem_, *viz_spatem_, *viz_mapem_;
   rviz_common::properties::BoolProperty *show_spatem_start_time, *show_spatem_min_end_time, *show_spatem_max_end_time, *show_spatem_likely_time, *show_spatem_confidence, *show_spatem_next_time;
   rviz_common::properties::FloatProperty *mapem_timeout_, *spatem_timeout_, *char_height_mapem_, *char_height_spatem_, *lane_width_property_, *spatem_sphere_scale_property_;
   rviz_common::properties::ColorProperty *color_property_ingress_, *color_property_egress_, *text_color_property_mapem_, *text_color_property_spatem_;

--- a/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
+++ b/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
@@ -84,6 +84,12 @@ protected:
   void update(float wall_dt, float ros_dt) override;
   void SPATEMCallback(etsi_its_spatem_ts_msgs::msg::SPATEM::ConstSharedPtr msg);
 
+  void RenderMapemShapes(Ogre::SceneNode *child_scene_node);
+  void RenderMapemShapes(Ogre::SceneNode *child_scene_node, IntersectionLane& lane);
+  void RenderMapemTexts(Ogre::SceneNode *child_scene_node, IntersectionRenderObject& intsctn);
+  void RenderSpatemShapes(Ogre::SceneNode *child_scene_node, IntersectionLane& lane, IntersectionMovementState* intersection_movement_state);
+  void RenderSpatemTexts(Ogre::SceneNode *child_scene_node, IntersectionLane& lane, IntersectionMovementState* intersection_movement_state);
+
   Ogre::ManualObject *manual_object_;
 
   rclcpp::Node::SharedPtr rviz_node_;

--- a/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
+++ b/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
@@ -77,6 +77,7 @@ public:
 protected Q_SLOTS:
   void changedSPATEMViz();
   void changedSPATEMTopic();
+  void changedMAPEMViz();
 
 protected:
   void processMessage(etsi_its_mapem_ts_msgs::msg::MAPEM::ConstSharedPtr msg) override;
@@ -90,9 +91,10 @@ protected:
   rclcpp::QoS spatem_qos_profile_ = rclcpp::QoS(1);
 
   // Properties
-  rviz_common::properties::BoolProperty *show_meta_, *viz_spatem_;
-  rviz_common::properties::FloatProperty *mapem_timeout_, *spatem_timeout_, *char_height_, *lane_width_property_, *spatem_sphere_scale_property_;
-  rviz_common::properties::ColorProperty *color_property_ingress_, *color_property_egress_, *text_color_property_;
+  rviz_common::properties::BoolProperty *show_meta_spatem_, *show_meta_mapem_, *viz_spatem_, *viz_mapem_, *show_spatem_;
+  rviz_common::properties::BoolProperty *show_spatem_start_time, *show_spatem_min_end_time, *show_spatem_max_end_time, *show_spatem_likely_time, *show_spatem_confidence, *show_spatem_next_time;
+  rviz_common::properties::FloatProperty *mapem_timeout_, *spatem_timeout_, *char_height_mapem_, *char_height_spatem_, *lane_width_property_, *spatem_sphere_scale_property_;
+  rviz_common::properties::ColorProperty *color_property_ingress_, *color_property_egress_, *text_color_property_mapem_, *text_color_property_spatem_;
   rviz_common::properties::RosTopicProperty *spatem_topic_property_;
   rviz_common::properties::QosProfileProperty *spatem_qos_property_;
 

--- a/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
+++ b/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
@@ -85,7 +85,7 @@ protected:
   void SPATEMCallback(etsi_its_spatem_ts_msgs::msg::SPATEM::ConstSharedPtr msg);
 
   void RenderMapemShapes(Ogre::SceneNode *child_scene_node);
-  void RenderMapemShapes(Ogre::SceneNode *child_scene_node, IntersectionLane& lane);
+  void RenderMapemShapesLane(Ogre::SceneNode *child_scene_node, IntersectionLane& lane);
   void RenderMapemTexts(Ogre::SceneNode *child_scene_node, IntersectionRenderObject& intsctn);
   void RenderSpatemShapes(Ogre::SceneNode *child_scene_node, IntersectionLane& lane, IntersectionMovementState* intersection_movement_state);
   void RenderSpatemTexts(Ogre::SceneNode *child_scene_node, IntersectionLane& lane, IntersectionMovementState* intersection_movement_state);

--- a/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
@@ -333,7 +333,6 @@ void MAPEMDisplay::RenderMapemTexts(Ogre::SceneNode *child_scene_node, Intersect
   height+=text_render->getBoundingRadius();
   
   Ogre::Vector3 offs(0.0, 0.0, height);
-  // There is a bug in rviz_rendering::MovableText::setGlobalTranslation https://github.com/ros2/rviz/issues/974
   text_render->setGlobalTranslation(offs);
   Ogre::ColourValue text_color = rviz_common::properties::qtToOgre(text_color_property_mapem_->getColor());
   text_render->setColor(text_color);
@@ -508,7 +507,6 @@ void MAPEMDisplay::update(float, float) {
           mvmnt_it = intsctn.movement_states.find(intsctn.lanes[i].signal_group_ids[j]);
           if (mvmnt_it != intsctn.movement_states.end())
           {
-            // todo: what happens if more than one entries are available?
             mvmnt_ptr = &mvmnt_it->second;
             break;
           }

--- a/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
@@ -108,7 +108,7 @@ MAPEMDisplay::MAPEMDisplay() {
     "Text color", show_meta_spatem_);
   char_height_spatem_ = new rviz_common::properties::FloatProperty("Scale", 1.0, "Scale of text", show_meta_spatem_);
 
-  show_spatem_start_time = new rviz_common::properties::BoolProperty("Start time", true,
+  show_spatem_start_time = new rviz_common::properties::BoolProperty("Start time", false,
     "Show SPATEM start time", show_meta_spatem_);
 
   show_spatem_min_end_time = new rviz_common::properties::BoolProperty("Min end time", true,
@@ -117,13 +117,13 @@ MAPEMDisplay::MAPEMDisplay() {
   show_spatem_max_end_time = new rviz_common::properties::BoolProperty("Max end time", true,
     "Show SPATEM max end time", show_meta_spatem_);
 
-  show_spatem_likely_time = new rviz_common::properties::BoolProperty("Likely time", true,
+  show_spatem_likely_time = new rviz_common::properties::BoolProperty("Likely time", false,
     "Show SPATEM likely time", show_meta_spatem_);
 
-  show_spatem_confidence = new rviz_common::properties::BoolProperty("Confidence", true,
+  show_spatem_confidence = new rviz_common::properties::BoolProperty("Confidence", false,
     "Show SPATEM confidence", show_meta_spatem_);
 
-  show_spatem_next_time = new rviz_common::properties::BoolProperty("Next time", true,
+  show_spatem_next_time = new rviz_common::properties::BoolProperty("Next time", false,
     "Show SPATEM next time", show_meta_spatem_);
 
 }

--- a/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
@@ -63,7 +63,7 @@ MAPEMDisplay::MAPEMDisplay() {
   
   // MAPEM
   viz_mapem_ = new rviz_common::properties::BoolProperty("Visualize MAPEMs", true,
-    "Show MAPEMs", this, SLOT(changedMAPEMViz()));
+    "Show MAPEMs", this);
 
   mapem_timeout_ = new rviz_common::properties::FloatProperty(
     "MAPEM Timeout", 120.0f,
@@ -162,10 +162,6 @@ void MAPEMDisplay::changedSPATEMViz() {
     spatem_subscriber_.reset();
   } 
   else changedSPATEMTopic();
-}
-
-void MAPEMDisplay::changedMAPEMViz() {
-  // todo
 }
 
 void MAPEMDisplay::changedSPATEMTopic() {
@@ -358,7 +354,7 @@ void MAPEMDisplay::RenderSpatemShapes(Ogre::SceneNode *child_scene_node, Interse
 
     // Set color according to state
     if(intersection_movement_state != nullptr) {
-      std::array<float, 4> color = etsi_its_spatem_ts_msgs::access::interpretMovementStatePhaseAsColor(intersection_movement_state->phase_state.value);
+      std::array<float, 4> color = etsi_its_spatem_ts_msgs::access::interpretMovementPhaseStateAsColor(intersection_movement_state->phase_state.value);
       sg->setColor(color.at(0), color.at(1), color.at(2), color.at(3));
     }
     else {
@@ -414,14 +410,14 @@ void MAPEMDisplay::RenderSpatemTexts(Ogre::SceneNode *child_scene_node, Intersec
       if (show_spatem_confidence->getBool()) {
         text_content += "Confidence: "
           + (time_change_details->confidence_is_present 
-            ? std::to_string((int)(etsi_its_spatem_ts_msgs::access::interpretTimeIntervalConfidenceAsPercent(time_change_details->confidence.value) * 100)) + "%" 
+            ? std::to_string((int)(etsi_its_spatem_ts_msgs::access::interpretTimeIntervalConfidenceAsFloat(time_change_details->confidence.value) * 100)) + "%" 
             : "-") 
           + "\n";
       }
       if (show_spatem_next_time->getBool()) {
         text_content += "Next time: "
           + (time_change_details->next_time_is_present 
-          ? std::to_string((int)(etsi_its_spatem_ts_msgs::access::interpretTimeIntervalConfidenceAsPercent(time_change_details->next_time.value) * 100)) + "%" 
+          ? etsi_its_spatem_ts_msgs::access::parseTimeMarkValueToString(time_change_details->next_time.value, header.stamp.sec, header.stamp.nanosec)
           : "-");
       }
     } else {


### PR DESCRIPTION

Changes:
Display "TimeChangeDetail" Etsi information as a text next to the corresponding traffic SPATEM 3D sphere object to visualize when a traffic change signal will occur.

![image](https://github.com/user-attachments/assets/c0198b7e-597a-4993-af23-675b2acce746)


The structure of the Rviz Treeview of MAPEM and SPATEM has been reorganized and new display properties for SPATEM metadata have been added.

![image](https://github.com/user-attachments/assets/1cc7bbe9-a808-495e-8cbb-4d8c75c51a87)

The visibility, text size, and color of the SPATEM information can be configured. In addition, the visibility for each SPATEM property can be configured individually. 

