### PR TITLE
Use `rbegin()` instead of `end()` to access last element of `std::map` storing the leap-second insertions

### DIFF
--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
@@ -41,11 +41,11 @@ SOFTWARE.
  *
  * @param generation_delta_time GenerationDeltaTime to set the GenerationDeltaTime-Value for
  * @param unix_nanosecs Timestamp in unix-nanoseconds to set the GenerationDeltaTime-Value from
- * @param n_leap_seconds Number of leap seconds since 2004 for the given timestamp (Default: etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second)
+ * @param n_leap_seconds Number of leap seconds since 2004 for the given timestamp (Defaults to the todays number of leap seconds since 2004.)
  */
 inline void setGenerationDeltaTime(
     GenerationDeltaTime& generation_delta_time, const uint64_t unix_nanosecs,
-    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second) {
+    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.rbegin()->second) {
   TimestampIts t_its;
   setTimestampITS(t_its, unix_nanosecs, n_leap_seconds);
   uint16_t gdt_value = t_its.value % 65536;
@@ -58,11 +58,11 @@ inline void setGenerationDeltaTime(
  *
  * @param cam CAM to set the GenerationDeltaTime-Value for
  * @param unix_nanosecs Timestamp in unix-nanoseconds to set the GenerationDeltaTime-Value from
- * @param n_leap_seconds Number of leap seconds since 2004 for the given timestamp  (Default: etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second)
+ * @param n_leap_seconds Number of leap seconds since 2004 for the given timestamp (Defaults to the todays number of leap seconds since 2004.)
  */
 inline void setGenerationDeltaTime(
     CAM& cam, const uint64_t unix_nanosecs,
-    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second) {
+    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.rbegin()->second) {
   setGenerationDeltaTime(cam.cam.generation_delta_time, unix_nanosecs, n_leap_seconds);
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_utils.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_utils.h
@@ -55,12 +55,12 @@ inline TimestampIts getTimestampITSFromGenerationDeltaTime(const GenerationDelta
  *
  * @param generation_delta_time the GenerationDeltaTime object to get the Unix-Nanoseconds from
  * @param timestamp_estimate estimated time to calculate the corresponding generation from
- * @param n_leap_seconds number of leap-seconds since 2004. (Default: etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second)
+ * @param n_leap_seconds number of leap-seconds since 2004. (Defaults to the todays number of leap seconds since 2004.)
  * @return uint64_t the corresponding Unix-Nanoseconds
  */
 inline uint64_t getUnixNanosecondsFromGenerationDeltaTime(
     const GenerationDeltaTime& generation_delta_time, const TimestampIts& timestamp_estimate,
-    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second) {
+    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.rbegin()->second) {
   TimestampIts t_its = getTimestampITSFromGenerationDeltaTime(generation_delta_time, timestamp_estimate);
   return t_its.value * 1e6 + etsi_its_msgs::UNIX_SECONDS_2004 * 1e9 - n_leap_seconds * 1e9;
 }
@@ -70,11 +70,12 @@ inline uint64_t getUnixNanosecondsFromGenerationDeltaTime(
  *
  * @param generation_delta_time the GenerationDeltaTime object to get the Unix-Nanoseconds from
  * @param unix_timestamp_estimate estimated unix-time (in Nanoseconds) to calculate the corresponding generation from
+ * @param n_leap_seconds number of leap-seconds since 2004. (Defaults to the todays number of leap seconds since 2004.)
  * @return uint64_t the corresponding Unix-Nanoseconds
  */
 inline uint64_t getUnixNanosecondsFromGenerationDeltaTime(
     const GenerationDeltaTime& generation_delta_time, const uint64_t unix_timestamp_estimate,
-    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second) {
+    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.rbegin()->second) {
   TimestampIts t_its;
   setTimestampITS(t_its, unix_timestamp_estimate, n_leap_seconds);
   return getUnixNanosecondsFromGenerationDeltaTime(generation_delta_time, t_its, n_leap_seconds);

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
@@ -42,12 +42,12 @@ SOFTWARE.
  *
  * @param[in] timestamp_its TimestampITS object to set the timestamp
  * @param[in] unix_nanosecs Unix-Nanoseconds to set the timestamp for
- * @param[in] n_leap_seconds Number of leap-seconds since 2004. (Default: etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second)
+ * @param[in] n_leap_seconds Number of leap-seconds since 2004. (Defaults to the todays number of leap seconds since 2004.)
  * @param[in] epoch_offset Unix-Timestamp in seconds for the 01.01.2004 at 00:00:00
  */
 inline void setTimestampITS(
     TimestampIts& timestamp_its, const uint64_t unix_nanosecs,
-    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second) {
+    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.rbegin()->second) {
   uint64_t t_its = unix_nanosecs * 1e-6 + (uint64_t)(n_leap_seconds * 1e3) - etsi_its_msgs::UNIX_SECONDS_2004 * 1e3;
   throwIfOutOfRange(t_its, TimestampIts::MIN, TimestampIts::MAX, "TimestampIts");
   timestamp_its.value = t_its;

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
@@ -65,7 +65,7 @@ inline void setItsPduHeader(CollectivePerceptionMessage& cpm, const uint32_t sta
  */
 inline void setReferenceTime(
     CollectivePerceptionMessage& cpm, const uint64_t unix_nanosecs,
-    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second) {
+    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.rbegin()->second) {
   TimestampIts t_its;
   setTimestampITS(t_its, unix_nanosecs, n_leap_seconds);
   throwIfOutOfRange(t_its.value, TimestampIts::MIN, TimestampIts::MAX, "TimestampIts");

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_setters.h
@@ -55,11 +55,11 @@ inline void setItsPduHeader(DENM& denm, const uint32_t station_id, const uint8_t
  * 
  * @param denm DENM to set the ReferenceTime-Value for
  * @param unix_nanosecs Timestamp in unix-nanoseconds to set the ReferenceTime-Value from
- * @param n_leap_seconds Number of leap seconds since 2004 for the given timestamp  (Default: etsi_its_msgs::N_LEAP_SECONDS)
+ * @param n_leap_seconds Number of leap seconds since 2004 for the given timestamp  (Defaults to the todays number of leap seconds since 2004.)
  */
 inline void setReferenceTime(
     DENM& denm, const uint64_t unix_nanosecs,
-    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second) {
+    const uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.rbegin()->second) {
   TimestampIts t_its;
   setTimestampITS(t_its, unix_nanosecs, n_leap_seconds);
   throwIfOutOfRange(t_its.value, TimestampIts::MIN, TimestampIts::MAX, "TimestampIts");

--- a/etsi_its_rviz_plugins/include/displays/CAM/cam_render_object.hpp
+++ b/etsi_its_rviz_plugins/include/displays/CAM/cam_render_object.hpp
@@ -45,7 +45,7 @@ namespace displays
 class CAMRenderObject
 {
   public:
-    CAMRenderObject(etsi_its_cam_msgs::msg::CAM cam, rclcpp::Time receive_time, uint16_t n_leap_seconds=etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.end()->second);
+    CAMRenderObject(etsi_its_cam_msgs::msg::CAM cam, rclcpp::Time receive_time, uint16_t n_leap_seconds=etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.rbegin()->second);
 
     /**
      * @brief This function validates all float variables that are part of a CAMRenderObject


### PR DESCRIPTION
This MR fixes a bug in multiple access functions where the number of leap-second insertions are relevant.