### PR TITLE
Improvement/display different utm zones at once

### DIFF
--- a/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
+++ b/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
@@ -107,6 +107,9 @@ protected:
   // Each Utm-SceneNode represents an utm frame
   std::map<std::string, Ogre::SceneNode*> scene_nodes_utm_;
 
+  // Each Junction-SceneNode represents the origin of a junction coordinate frame
+  std::map<uint, Ogre::SceneNode*> scene_nodes_junctions_;
+
   std::unordered_map<int, IntersectionRenderObject> intersections_;
   std::vector<std::shared_ptr<rviz_rendering::Shape>> intsct_ref_points_, signal_groups_;
   std::vector<std::shared_ptr<rviz_rendering::BillboardLine>> lane_lines_;

--- a/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
+++ b/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
@@ -99,7 +99,7 @@ protected:
   // Properties
   rviz_common::properties::BoolProperty *show_meta_spatem_, *show_meta_mapem_, *viz_spatem_, *viz_mapem_;
   rviz_common::properties::BoolProperty *show_spatem_start_time, *show_spatem_min_end_time, *show_spatem_max_end_time, *show_spatem_likely_time, *show_spatem_confidence, *show_spatem_next_time;
-  rviz_common::properties::FloatProperty *mapem_timeout_, *spatem_timeout_, *char_height_mapem_, *char_height_spatem_, *lane_width_property_, *spatem_sphere_scale_property_;
+  rviz_common::properties::FloatProperty *mapem_timeout_, *spatem_timeout_, *char_height_mapem_, *char_height_spatem_, *lane_width_property_, *spatem_sphere_scale_property_, *mapem_sphere_scale_property_;
   rviz_common::properties::ColorProperty *color_property_ingress_, *color_property_egress_, *text_color_property_mapem_, *text_color_property_spatem_;
   rviz_common::properties::RosTopicProperty *spatem_topic_property_;
   rviz_common::properties::QosProfileProperty *spatem_qos_property_;

--- a/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
+++ b/etsi_its_rviz_plugins/include/displays/MAPEM/mapem_display.hpp
@@ -104,6 +104,9 @@ protected:
   rviz_common::properties::RosTopicProperty *spatem_topic_property_;
   rviz_common::properties::QosProfileProperty *spatem_qos_property_;
 
+  // Each Utm-SceneNode represents an utm frame
+  std::map<std::string, Ogre::SceneNode*> scene_nodes_utm_;
+
   std::unordered_map<int, IntersectionRenderObject> intersections_;
   std::vector<std::shared_ptr<rviz_rendering::Shape>> intsct_ref_points_, signal_groups_;
   std::vector<std::shared_ptr<rviz_rendering::BillboardLine>> lane_lines_;

--- a/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
@@ -28,7 +28,6 @@ SOFTWARE.
 
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
-#include <OgreManualObject.h>
 #include <OgreBillboardSet.h>
 #include <OgreMaterialManager.h>
 #include <OgreTechnique.h>
@@ -129,9 +128,6 @@ MAPEMDisplay::MAPEMDisplay() {
 }
 
 MAPEMDisplay::~MAPEMDisplay() {
-  if (initialized() ) {
-    scene_manager_->destroyManualObject(manual_object_);
-  }
 }
 
 void MAPEMDisplay::onInitialize() {
@@ -145,15 +141,10 @@ void MAPEMDisplay::onInitialize() {
         spatem_qos_profile_ = profile;
         changedSPATEMTopic();
       });
-
-  manual_object_ = scene_manager_->createManualObject();
-  manual_object_->setDynamic(true);
-  scene_node_->attachObject(manual_object_);
 }
 
 void MAPEMDisplay::reset() {
   RTDClass::reset();
-  manual_object_->clear();
 }
 
 void MAPEMDisplay::changedSPATEMViz() {

--- a/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
@@ -91,7 +91,7 @@ MAPEMDisplay::MAPEMDisplay() {
   char_height_mapem_ = new rviz_common::properties::FloatProperty("Scale", 4.0, "Scale of text", show_meta_mapem_);
 
   // SPATEM
-  viz_spatem_ = new rviz_common::properties::BoolProperty("Visualize SPATEMs", false,
+  viz_spatem_ = new rviz_common::properties::BoolProperty("Visualize SPATEMs", true,
     "Show SPATEMs corresponding to received MAPEMs", this, SLOT(changedSPATEMViz()));
   
   spatem_timeout_ = new rviz_common::properties::FloatProperty(

--- a/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
@@ -69,6 +69,11 @@ MAPEMDisplay::MAPEMDisplay() {
     "Time (in s) until MAP disappears", viz_mapem_);
   mapem_timeout_->setMin(0);
 
+  mapem_sphere_scale_property_ = new rviz_common::properties::FloatProperty(
+    "MAPEM Sphere Scale", 1.0f,
+    "Scaling factor to adjuste size of MAPEM spheres", viz_mapem_);
+    mapem_sphere_scale_property_->setMin(0.1);
+
   color_property_ingress_ = new rviz_common::properties::ColorProperty(
     "Ingress Lane Color", QColor(85, 85, 255),
     "Color to visualize Ingress-Lanes", viz_mapem_);
@@ -280,7 +285,7 @@ void MAPEMDisplay::RenderMapemShapes(Ogre::SceneNode *child_scene_node) {
   std::shared_ptr<rviz_rendering::Shape> sphere = std::make_shared<rviz_rendering::Shape>(rviz_rendering::Shape::Sphere, scene_manager_, child_scene_node);
 
   // set the dimensions of sphere
-  double scale = spatem_sphere_scale_property_->getFloat();
+  double scale = mapem_sphere_scale_property_->getFloat();
   Ogre::Vector3 dims;
   dims.x = 1.0 * scale;
   dims.y = 1.0 * scale;
@@ -316,7 +321,7 @@ void MAPEMDisplay::RenderMapemTexts(Ogre::SceneNode *child_scene_node, Intersect
   std::string text;
   text+="IntersectionID: " + std::to_string(intsctn.getIntersectionID());
   std::shared_ptr<rviz_rendering::MovableText> text_render = std::make_shared<rviz_rendering::MovableText>(text, "Liberation Sans", char_height_mapem_->getFloat());
-  double height = spatem_sphere_scale_property_->getFloat();
+  double height = mapem_sphere_scale_property_->getFloat();
   height+=text_render->getBoundingRadius();
   
   Ogre::Vector3 offs(0.0, 0.0, height);

--- a/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
@@ -467,9 +467,16 @@ void MAPEMDisplay::update(float, float) {
     scene_nodes_utm_[utm_frame_key]->setPosition(sn_position);
     scene_nodes_utm_[utm_frame_key]->setOrientation(sn_orientation);
 
-    auto child_scene_node = scene_nodes_utm_[utm_frame_key]->createChildSceneNode();
-
     // Set position of scene node
+    uint intersection_id = intsctn.getIntersectionID();
+
+    if (scene_nodes_junctions_.find(intersection_id) == scene_nodes_junctions_.end()) {
+      Ogre::SceneNode* scene_node = scene_nodes_utm_[utm_frame_key]->createChildSceneNode(std::string("Junction: ") + std::to_string(intersection_id));
+      scene_nodes_junctions_.insert({intersection_id, scene_node});
+    }
+
+    auto child_scene_node = scene_nodes_junctions_[intersection_id];
+
     geometry_msgs::msg::Point ref_position = intsctn.getRefPosition();
     Ogre::Vector3 position(ref_position.x, ref_position.y, ref_position.z);
     tf2::Quaternion rot_offset = intsctn.getGridConvergenceQuaternion();


### PR DESCRIPTION
Added the possibility to visualize entities in several different coordinate frames at once within the Mapem/Spatem RViz plugin.
This is necessary when the displayed entities are located within multiple Utm zones, which can happen when the workspace is located near Utm boundaries.
The previous implementation was only able to correctly display objects within a single coordinate frame.
Additionally, a memory leak was fixed where an Ogre3D SceneNode was periodically created inside the update loop without being destroyed afterwards.