### PR TITLE
Fix visualization of SPATEMS on Startup of RViz

### DIFF
--- a/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
@@ -146,6 +146,7 @@ void MAPEMDisplay::onInitialize() {
         spatem_qos_profile_ = profile;
         changedSPATEMTopic();
       });
+  changedSPATEMViz();
 }
 
 void MAPEMDisplay::reset() {

--- a/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
@@ -151,6 +151,11 @@ void MAPEMDisplay::onInitialize() {
 
 void MAPEMDisplay::reset() {
   RTDClass::reset();
+  intersections_.clear();
+  intsct_ref_points_.clear();
+  lane_lines_.clear();
+  signal_groups_.clear();
+  texts_.clear();
 }
 
 void MAPEMDisplay::changedSPATEMViz() {


### PR DESCRIPTION
In #70, the MAPEM plugin was changed so that the SPATEMs should be visualised by default.
However, no SPATEMs were visualised until a change was made to the properties.

With this PR, the function `changedSPATEMViz` is initially called in `onInitialize` to set up the subscriber correctly.

Additionally all visualized members and subscribed intersections are cleared on reset.