### PR TITLE
Add setters and getters for (co)variances

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,5 +1,8 @@
 {
     "version": "2.0.0",
+    "options": {
+        "cwd": "${env:WORKSPACE}"
+    },
     "tasks": [
         {
             "label": "Download external dependencies",
@@ -11,8 +14,30 @@
             "label": "Patch ASN.1 files",
             "type": "shell",
             "command": "./asn1/patches/patch.sh",
-            "dependsOn": ["Download external dependencies"],
+            "dependsOn": [
+                "Download external dependencies"
+            ],
             "problemMatcher": []
-        }
+        },
+        // === Build ==========
+        {
+            "label": "Build",
+            "detail": "Builds ROS workspace using 'colcon'",
+            "type": "shell",
+            "command": "colcon build --symlink-install --cmake-args '-DCMAKE_BUILD_TYPE=Debug' '-DCMAKE_EXPORT_COMPILE_COMMANDS=1'",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$gcc"
+        },
+        {
+            "label": "Build with Build Type",
+            "detail": "Builds ROS workspace using 'colcon' with given build type",
+            "type": "shell",
+            "command": "colcon build --symlink-install --cmake-args '-DCMAKE_BUILD_TYPE=${input:cmake_build_type}' '-DCMAKE_EXPORT_COMPILE_COMMANDS=1'",
+            "group": "build",
+            "problemMatcher": "$gcc"
+        },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,8 +1,5 @@
 {
     "version": "2.0.0",
-    "options": {
-        "cwd": "${env:WORKSPACE}"
-    },
     "tasks": [
         {
             "label": "Download external dependencies",
@@ -14,30 +11,8 @@
             "label": "Patch ASN.1 files",
             "type": "shell",
             "command": "./asn1/patches/patch.sh",
-            "dependsOn": [
-                "Download external dependencies"
-            ],
+            "dependsOn": ["Download external dependencies"],
             "problemMatcher": []
-        },
-        // === Build ==========
-        {
-            "label": "Build",
-            "detail": "Builds ROS workspace using 'colcon'",
-            "type": "shell",
-            "command": "colcon build --symlink-install --cmake-args '-DCMAKE_BUILD_TYPE=Debug' '-DCMAKE_EXPORT_COMPILE_COMMANDS=1'",
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "problemMatcher": "$gcc"
-        },
-        {
-            "label": "Build with Build Type",
-            "detail": "Builds ROS workspace using 'colcon' with given build type",
-            "type": "shell",
-            "command": "colcon build --symlink-install --cmake-args '-DCMAKE_BUILD_TYPE=${input:cmake_build_type}' '-DCMAKE_EXPORT_COMPILE_COMMANDS=1'",
-            "group": "build",
-            "problemMatcher": "$gcc"
-        },
+        }
     ]
 }

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters.h
@@ -56,4 +56,9 @@ inline double getLateralAcceleration(const LateralAcceleration& lateral_accelera
 
 #include <etsi_its_msgs_utils/impl/cam/cam_getters_common.h>
 
+inline const std::array<double, 4> getRefPosConfidence(CAM& cam) {
+  double object_heading = getHeading(cam) * M_PI / 180.0;
+  return getPosConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse, object_heading);
+}
+
 }  // namespace etsi_its_cam_msgs::access

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters.h
@@ -70,4 +70,17 @@ inline const std::array<double, 4> getRefPosConfidence(CAM& cam) {
   return getPosConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse, object_heading);
 }
 
+/**
+ * @brief Get the confidence ellipse of the reference position as Covariance matrix
+ * 
+ * The covariance matrix will have the entries cov_xx, cov_xy, cov_yx, cov_yy
+ * where x is WGS84 North and y is East
+ * 
+ * @param cam The CAM message to get the reference position from
+ * @return const std::array<double, 4> the covariance matrix, as specified above
+ */
+inline const std::array<double, 4> getWGSRefPosConfidence(CAM& cam) {
+  return getWGSPosConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse);
+}
+
 }  // namespace etsi_its_cam_msgs::access

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters.h
@@ -44,6 +44,10 @@ inline double getLongitudinalAcceleration(const LongitudinalAcceleration& longit
   return ((double)longitudinal_acceleration.longitudinal_acceleration_value.value) * 1e-1;
 }
 
+inline double getLongitudinalAccelerationConfidence(const LongitudinalAcceleration& longitudinal_acceleration) {
+  return ((double)longitudinal_acceleration.longitudinal_acceleration_confidence.value) * 1e-1 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
+}
+
 /**
  * @brief Get the lateral acceleration
  *
@@ -52,6 +56,10 @@ inline double getLongitudinalAcceleration(const LongitudinalAcceleration& longit
  */
 inline double getLateralAcceleration(const LateralAcceleration& lateral_acceleration) {
   return ((double)lateral_acceleration.lateral_acceleration_value.value) * 1e-1;
+}
+
+inline double getLateralAccelerationConfidence(const LateralAcceleration& lateral_acceleration) {
+  return ((double)lateral_acceleration.lateral_acceleration_confidence.value) * 1e-1 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
 }
 
 #include <etsi_its_msgs_utils/impl/cam/cam_getters_common.h>

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters.h
@@ -56,6 +56,15 @@ inline double getLateralAcceleration(const LateralAcceleration& lateral_accelera
 
 #include <etsi_its_msgs_utils/impl/cam/cam_getters_common.h>
 
+/**
+ * @brief Get the confidence ellipse of the reference position as Covariance matrix
+ * 
+ * The covariance matrix will have the entries cov_xx, cov_xy, cov_yx, cov_yy
+ * where x is the longitudinal axis and y is the lateral axis of the vehicle.
+ * 
+ * @param cam The CAM message to get the reference position from
+ * @return const std::array<double, 4> the covariance matrix, as specified above
+ */
 inline const std::array<double, 4> getRefPosConfidence(CAM& cam) {
   double object_heading = getHeading(cam) * M_PI / 180.0;
   return getPosConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse, object_heading);

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters.h
@@ -85,7 +85,7 @@ inline double getLateralAccelerationConfidence(const LateralAcceleration& latera
  * @param cam The CAM message to get the reference position from
  * @return const std::array<double, 4> the covariance matrix, as specified above
  */
-inline const std::array<double, 4> getRefPosConfidence(CAM& cam) {
+inline const std::array<double, 4> getRefPosConfidence(const CAM& cam) {
   double object_heading = getHeading(cam) * M_PI / 180.0;
   return getPosConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse, object_heading);
 }
@@ -99,7 +99,7 @@ inline const std::array<double, 4> getRefPosConfidence(CAM& cam) {
  * @param cam The CAM message to get the reference position from
  * @return const std::array<double, 4> the covariance matrix, as specified above
  */
-inline const std::array<double, 4> getWGSRefPosConfidence(CAM& cam) {
+inline const std::array<double, 4> getWGSRefPosConfidence(const CAM& cam) {
   return getWGSPosConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse);
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters.h
@@ -38,12 +38,18 @@ namespace etsi_its_cam_msgs::access {
  * @brief Get the longitudinal acceleration
  *
  * @param longitudinalAcceleration to get the longitudinal acceleration from
- * @return longitudinal acceleration in m/s^2 as decimal number (left is positive)
+ * @return longitudinal acceleration in m/s^2 as decimal number (accelerating is positive)
  */
 inline double getLongitudinalAcceleration(const LongitudinalAcceleration& longitudinal_acceleration) {
   return ((double)longitudinal_acceleration.longitudinal_acceleration_value.value) * 1e-1;
 }
 
+/**
+ * @brief Get the Longitudinal Acceleration Confidence
+ * 
+ * @param longitudinal_acceleration to get the LongitudinalAccelerationConfidence from
+ * @return double standard deviation of the longitudinal acceleration in m/s^2 as decimal number
+ */
 inline double getLongitudinalAccelerationConfidence(const LongitudinalAcceleration& longitudinal_acceleration) {
   return ((double)longitudinal_acceleration.longitudinal_acceleration_confidence.value) * 1e-1 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
 }
@@ -58,6 +64,12 @@ inline double getLateralAcceleration(const LateralAcceleration& lateral_accelera
   return ((double)lateral_acceleration.lateral_acceleration_value.value) * 1e-1;
 }
 
+/**
+ * @brief Get the Lateral Acceleration Confidence
+ * 
+ * @param longitudinal_acceleration to get the LateralAccelerationConfidence from
+ * @return double standard deviation of the lateral acceleration in m/s^2 as decimal number
+ */
 inline double getLateralAccelerationConfidence(const LateralAcceleration& lateral_acceleration) {
   return ((double)lateral_acceleration.lateral_acceleration_confidence.value) * 1e-1 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
 }

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
@@ -97,16 +97,6 @@ inline double getAltitude(const CAM& cam) {
 }
 
 /**
- * @brief Get the Heading value
- *
- * 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West
- *
- * @param heading to get the Heading value from
- * @return Heading value in degree as decimal number
- */
-inline double getHeading(const Heading& heading) { return ((double)heading.heading_value.value) * 1e-1; }
-
-/**
  * @brief Get the Heading value of CAM
  *
  * 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West
@@ -115,7 +105,7 @@ inline double getHeading(const Heading& heading) { return ((double)heading.headi
  * @return Heading value in degree as decimal number
  */
 inline double getHeading(const CAM& cam) {
-  return getHeading(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.heading);
+  return getHeadingInternal(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.heading);
 }
 
 /**

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
@@ -105,7 +105,7 @@ inline double getAltitude(const CAM& cam) {
  * @return Heading value in degree as decimal number
  */
 inline double getHeading(const CAM& cam) {
-  return getHeadingInternal(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.heading);
+  return getHeadingCDD(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.heading);
 }
 
 /**
@@ -158,6 +158,12 @@ inline double getSpeed(const CAM& cam) {
   return getSpeed(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.speed);
 }
 
+/**
+ * @brief Get the Speed Confidence
+ * 
+ * @param cam CAM to get the Speed Confidence from
+ * @return double standard deviation of the speed in m/s as decimal number
+ */
 inline double getSpeedConfidence(const CAM& cam) {
   return getSpeedConfidence(
       cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.speed);

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
@@ -109,6 +109,17 @@ inline double getHeading(const CAM& cam) {
 }
 
 /**
+ * @brief Get the Heading confidence of CAM
+ *
+ *
+ * @param cam CAM to get the Heading confidence from
+ * @return Heading standard deviation in degree as decimal number
+ */
+inline double getHeadingConfidence(const CAM& cam) {
+  return getHeadingConfidenceCDD(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.heading);
+}
+
+/**
  * @brief Get the Vehicle Length
  *
  * @param vehicleLength to get the vehicle length value from

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
@@ -158,6 +158,11 @@ inline double getSpeed(const CAM& cam) {
   return getSpeed(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.speed);
 }
 
+inline double getSpeedConfidence(const CAM& cam) {
+  return getSpeedConfidence(
+      cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.speed);
+}
+
 /**
  * @brief Get the longitudinal acceleration
  *
@@ -166,6 +171,11 @@ inline double getSpeed(const CAM& cam) {
  */
 inline double getLongitudinalAcceleration(const CAM& cam) {
   return getLongitudinalAcceleration(
+      cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.longitudinal_acceleration);
+}
+
+inline double getLongitudinalAccelerationConfidence(const CAM& cam) {
+  return getLongitudinalAccelerationConfidence(
       cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.longitudinal_acceleration);
 }
 
@@ -182,6 +192,16 @@ inline double getLateralAcceleration(const CAM& cam) {
         cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.lateral_acceleration);
   } else {
     throw std::invalid_argument("LateralAcceleration is not present!");
+  }
+}
+
+inline double getLateralAccelerationConfidence(const CAM& cam) {
+  if (cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency
+          .lateral_acceleration_is_present) {
+    return getLateralAccelerationConfidence(
+        cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.lateral_acceleration);
+  } else {
+    throw std::invalid_argument("LateralAccelerationConfidence is not present!");
   }
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
@@ -167,13 +167,19 @@ inline double getSpeedConfidence(const CAM& cam) {
  * @brief Get the longitudinal acceleration
  *
  * @param cam CAM to get the longitudinal acceleration from
- * @return longitudinal acceleration in m/s^2 as decimal number (left is positive)
+ * @return longitudinal acceleration in m/s^2 as decimal number (accelerating is positive)
  */
 inline double getLongitudinalAcceleration(const CAM& cam) {
   return getLongitudinalAcceleration(
       cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.longitudinal_acceleration);
 }
 
+/**
+ * @brief Get the Longitudinal Acceleration Confidence
+ * 
+ * @param cam CAM to get the LongitudinalAccelerationConfidence from
+ * @return double standard deviation of the longitudinal acceleration in m/s^2 as decimal number
+ */
 inline double getLongitudinalAccelerationConfidence(const CAM& cam) {
   return getLongitudinalAccelerationConfidence(
       cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.longitudinal_acceleration);
@@ -195,6 +201,12 @@ inline double getLateralAcceleration(const CAM& cam) {
   }
 }
 
+/**
+ * @brief Get the Lateral Acceleration Confidence 
+ * 
+ * @param cam CAM to get the LateralAccelerationConfidence from
+ * @return double standard deviation of the lateral acceleration in m/s^2 as decimal number
+ */
 inline double getLateralAccelerationConfidence(const CAM& cam) {
   if (cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency
           .lateral_acceleration_is_present) {

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters.h
@@ -133,4 +133,17 @@ inline void setRefPosConfidence(CAM& cam, const std::array<double, 4>& covarianc
                           covariance_matrix, object_heading);
 }
 
+/**
+ * @brief Set the confidence of the reference position
+ * 
+ * @param cam CAM-Message to set the confidence
+ * @param covariance_matrix The four values of the covariance matrix in the order: cov_xx, cov_xy, cov_yx, cov_yy
+ *                          The matrix has to be SPD, otherwise a std::invalid_argument exception is thrown.
+ *                          Its coordinate system is WGS84 (x = North, y = East)
+ */
+inline void setWGSRefPosConfidence(CAM& cam, const std::array<double, 4>& covariance_matrix) {
+  setWGSPosConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse,
+                             covariance_matrix);
+}
+
 }  // namespace etsi_its_cam_msgs::access

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters.h
@@ -55,7 +55,7 @@ inline void setItsPduHeader(CAM &cam, const uint32_t station_id, const uint8_t p
 inline void setLongitudinalAccelerationValue(LongitudinalAccelerationValue& accel, const double value) {
   auto accel_val = std::round(value * 1e1);
   if (accel_val >= LongitudinalAccelerationValue::MIN && accel_val <= LongitudinalAccelerationValue::MAX) {
-    accel.value = accel_val;
+    accel.value = static_cast<int16_t>(accel_val);
   } else if (accel_val < LongitudinalAccelerationValue::MIN) {
     accel.value = LongitudinalAccelerationValue::MIN;
   } else if (accel_val > LongitudinalAccelerationValue::MAX) {

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters.h
@@ -108,4 +108,29 @@ inline void setLateralAcceleration(LateralAcceleration& accel, const double valu
 
 #include <etsi_its_msgs_utils/impl/cam/cam_setters_common.h>
 
+/**
+ * @brief Set the confidence of the reference position
+ * 
+ * @param cam CAM-Message to set the confidence
+ * @param covariance_matrix The four values of the covariance matrix in the order: cov_xx, cov_xy, cov_yx, cov_yy
+ *                          The matrix has to be SPD, otherwise a std::invalid_argument exception is thrown.
+ *                          Its coordinate system is aligned with the object (x = longitudinal, y = lateral)
+ * @param object_heading heading of the object in rad, with respect to WGS84
+ */
+inline void setRefPosConfidence(CAM& cam, const std::array<double, 4>& covariance_matrix, const double object_heading) {
+  // First ensure, that the object has the correct heading by setting its value
+  double orientation = object_heading * 180 / M_PI; // Convert to degrees
+  // Normalize to [0, 360)
+  orientation = std::fmod(orientation + 360, 360);
+  while (orientation < 0) {
+    orientation += 360;
+  }
+  while (orientation >= 360) {
+    orientation -= 360;
+  }
+  setHeading(cam, orientation);
+  setPosConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse,
+                          covariance_matrix, object_heading);
+}
+
 }  // namespace etsi_its_cam_msgs::access

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters.h
@@ -53,7 +53,7 @@ inline void setItsPduHeader(CAM &cam, const uint32_t station_id, const uint8_t p
  * @param value LongitudinalAccelerationValue in m/s^2 as decimal number (braking is negative)
  */
 inline void setLongitudinalAccelerationValue(LongitudinalAccelerationValue& accel, const double value) {
-  int64_t accel_val = (int64_t)std::round(value * 1e1);
+  auto accel_val = std::round(value * 1e1);
   if (accel_val >= LongitudinalAccelerationValue::MIN && accel_val <= LongitudinalAccelerationValue::MAX) {
     accel.value = accel_val;
   } else if (accel_val < LongitudinalAccelerationValue::MIN) {
@@ -71,8 +71,8 @@ inline void setLongitudinalAccelerationValue(LongitudinalAccelerationValue& acce
  * @param accel object to set
  * @param value LongitudinalAccelerationValue in m/s^2 as decimal number (braking is negative)
  */
-inline void setLongitudinalAcceleration(LongitudinalAcceleration& accel, const double value) {
-  accel.longitudinal_acceleration_confidence.value = AccelerationConfidence::UNAVAILABLE;
+inline void setLongitudinalAcceleration(LongitudinalAcceleration& accel, const double value, const double confidence = AccelerationConfidence::UNAVAILABLE) {
+  setAccelerationConfidence(accel.longitudinal_acceleration_confidence, confidence);
   setLongitudinalAccelerationValue(accel.longitudinal_acceleration_value, value);
 }
 
@@ -101,8 +101,8 @@ inline void setLateralAccelerationValue(LateralAccelerationValue& accel, const d
  * @param accel object to set
  * @param value LaterallAccelerationValue in m/s^2 as decimal number (left is positive)
  */
-inline void setLateralAcceleration(LateralAcceleration& accel, const double value) {
-  accel.lateral_acceleration_confidence.value = AccelerationConfidence::UNAVAILABLE;
+inline void setLateralAcceleration(LateralAcceleration& accel, const double value, const double confidence = AccelerationConfidence::UNAVAILABLE) {
+  setAccelerationConfidence(accel.lateral_acceleration_confidence, confidence);
   setLateralAccelerationValue(accel.lateral_acceleration_value, value);
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters.h
@@ -70,6 +70,8 @@ inline void setLongitudinalAccelerationValue(LongitudinalAccelerationValue& acce
  *
  * @param accel object to set
  * @param value LongitudinalAccelerationValue in m/s^2 as decimal number (braking is negative)
+ * @param confidence standard deviation of the longitudinal acceleration in m/s^2 as decimal number
+ *                   Default is AccelerationConfidence::UNAVAILABLE
  */
 inline void setLongitudinalAcceleration(LongitudinalAcceleration& accel, const double value, const double confidence = AccelerationConfidence::UNAVAILABLE) {
   setAccelerationConfidence(accel.longitudinal_acceleration_confidence, confidence);
@@ -100,6 +102,8 @@ inline void setLateralAccelerationValue(LateralAccelerationValue& accel, const d
  *
  * @param accel object to set
  * @param value LaterallAccelerationValue in m/s^2 as decimal number (left is positive)
+ * @param confidence standard deviation of the lateral acceleration in m/s^2 as decimal number
+ *                   Default is AccelerationConfidence::UNAVAILABLE
  */
 inline void setLateralAcceleration(LateralAcceleration& accel, const double value, const double confidence = AccelerationConfidence::UNAVAILABLE) {
   setAccelerationConfidence(accel.lateral_acceleration_confidence, confidence);

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters.h
@@ -71,9 +71,9 @@ inline void setLongitudinalAccelerationValue(LongitudinalAccelerationValue& acce
  * @param accel object to set
  * @param value LongitudinalAccelerationValue in m/s^2 as decimal number (braking is negative)
  * @param confidence standard deviation of the longitudinal acceleration in m/s^2 as decimal number
- *                   Default is AccelerationConfidence::UNAVAILABLE
+ *                   Default is infinity, mapping to AccelerationConfidence::UNAVAILABLE
  */
-inline void setLongitudinalAcceleration(LongitudinalAcceleration& accel, const double value, const double confidence = AccelerationConfidence::UNAVAILABLE) {
+inline void setLongitudinalAcceleration(LongitudinalAcceleration& accel, const double value, const double confidence = std::numeric_limits<double>::infinity()) {
   setAccelerationConfidence(accel.longitudinal_acceleration_confidence, confidence);
   setLongitudinalAccelerationValue(accel.longitudinal_acceleration_value, value);
 }
@@ -103,9 +103,9 @@ inline void setLateralAccelerationValue(LateralAccelerationValue& accel, const d
  * @param accel object to set
  * @param value LaterallAccelerationValue in m/s^2 as decimal number (left is positive)
  * @param confidence standard deviation of the lateral acceleration in m/s^2 as decimal number
- *                   Default is AccelerationConfidence::UNAVAILABLE
+ *                   Default is infinity, mapping to AccelerationConfidence::UNAVAILABLE
  */
-inline void setLateralAcceleration(LateralAcceleration& accel, const double value, const double confidence = AccelerationConfidence::UNAVAILABLE) {
+inline void setLateralAcceleration(LateralAcceleration& accel, const double value, const double confidence = std::numeric_limits<double>::infinity()) {
   setAccelerationConfidence(accel.lateral_acceleration_confidence, confidence);
   setLateralAccelerationValue(accel.lateral_acceleration_value, value);
 }

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
@@ -158,9 +158,9 @@ inline void setSpeed(CAM& cam, const double speed_val, const double confidence =
  * @param cam CAM to set the acceleration value s
  * @param lon_accel longitudinal acceleration to set in m/s^2 as decimal number (braking is negative), if not available use 16.1 m/s^2
  * @param confidence standard deviation of the longitudinal acceleration in m/s^2 as decimal number
- *                   Default is AccelerationConfidence::UNAVAILABLE
+ *                   Default is infinity, mapping to AccelerationConfidence::UNAVAILABLE
  */
-inline void setLongitudinalAcceleration(CAM& cam, const double lon_accel, const double confidence = AccelerationConfidence::UNAVAILABLE) {
+inline void setLongitudinalAcceleration(CAM& cam, const double lon_accel, const double confidence = std::numeric_limits<double>::infinity()) {
   setLongitudinalAcceleration(
       cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.longitudinal_acceleration,
       lon_accel, confidence);
@@ -172,9 +172,9 @@ inline void setLongitudinalAcceleration(CAM& cam, const double lon_accel, const 
  * @param cam CAM to set the acceleration value s
  * @param lat_accel lateral acceleration to set in m/s^2 as decimal number (left is positiv), if not available use 16.1 m/s^2
  * @param confidence standard deviation of the lateral acceleration in m/s^2 as decimal number
- *                   Default is AccelerationConfidence::UNAVAILABLE
+ *                   Default is infinity, mapping to AccelerationConfidence::UNAVAILABLE
  */
-inline void setLateralAcceleration(CAM& cam, const double lat_accel, const double confidence = AccelerationConfidence::UNAVAILABLE) {
+inline void setLateralAcceleration(CAM& cam, const double lat_accel, const double confidence = std::numeric_limits<double>::infinity()) {
   setLateralAcceleration(
       cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.lateral_acceleration,
       lat_accel, confidence);

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
@@ -157,6 +157,8 @@ inline void setSpeed(CAM& cam, const double speed_val, const double confidence =
  *
  * @param cam CAM to set the acceleration value s
  * @param lon_accel longitudinal acceleration to set in m/s^2 as decimal number (braking is negative), if not available use 16.1 m/s^2
+ * @param confidence standard deviation of the longitudinal acceleration in m/s^2 as decimal number
+ *                   Default is AccelerationConfidence::UNAVAILABLE
  */
 inline void setLongitudinalAcceleration(CAM& cam, const double lon_accel, const double confidence = AccelerationConfidence::UNAVAILABLE) {
   setLongitudinalAcceleration(
@@ -169,6 +171,8 @@ inline void setLongitudinalAcceleration(CAM& cam, const double lon_accel, const 
  *
  * @param cam CAM to set the acceleration value s
  * @param lat_accel lateral acceleration to set in m/s^2 as decimal number (left is positiv), if not available use 16.1 m/s^2
+ * @param confidence standard deviation of the lateral acceleration in m/s^2 as decimal number
+ *                   Default is AccelerationConfidence::UNAVAILABLE
  */
 inline void setLateralAcceleration(CAM& cam, const double lat_accel, const double confidence = AccelerationConfidence::UNAVAILABLE) {
   setLateralAcceleration(

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
@@ -86,7 +86,7 @@ inline void setStationType(CAM& cam, const uint8_t value) {
  * @param value Heading value in degree as decimal number
  */
 inline void setHeading(CAM& cam, const double heading_val) {
-  setHeading(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.heading,
+  setHeadingInternal(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.heading,
              heading_val);
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
@@ -86,7 +86,7 @@ inline void setStationType(CAM& cam, const uint8_t value) {
  * @param value Heading value in degree as decimal number
  */
 inline void setHeading(CAM& cam, const double heading_val) {
-  setHeadingInternal(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.heading,
+  setHeadingCDD(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.heading,
              heading_val);
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
@@ -77,34 +77,6 @@ inline void setStationType(CAM& cam, const uint8_t value) {
 }
 
 /**
- * @brief Set the HeadingValue object
- *
- * 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West
- *
- * @param heading object to set
- * @param value Heading value in degree as decimal number
- */
-inline void setHeadingValue(HeadingValue& heading, const double value) {
-  int64_t deg = (int64_t)std::round(value * 1e1);
-  throwIfOutOfRange(deg, HeadingValue::MIN, HeadingValue::MAX, "HeadingValue");
-  heading.value = deg;
-}
-
-/**
- * @brief Set the Heading object
- *
- * 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West
- * HeadingConfidence is set to UNAVAILABLE
- *
- * @param heading object to set
- * @param value Heading value in degree as decimal number
- */
-inline void setHeading(Heading& heading, const double value) {
-  heading.heading_confidence.value = HeadingConfidence::UNAVAILABLE;
-  setHeadingValue(heading.heading_value, value);
-}
-
-/**
  * @brief Set the Heading for a CAM
  *
  * 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
@@ -148,8 +148,8 @@ inline void setVehicleDimensions(CAM& cam, const double vehicle_length, const do
  * @param cam CAM to set the speed value
  * @param speed_val speed value to set in m/s as decimal number
  */
-inline void setSpeed(CAM& cam, const double speed_val) {
-  setSpeed(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.speed, speed_val);
+inline void setSpeed(CAM& cam, const double speed_val, const double confidence = SpeedConfidence::UNAVAILABLE) {
+  setSpeed(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.speed, speed_val, confidence);
 }
 
 /**
@@ -158,10 +158,10 @@ inline void setSpeed(CAM& cam, const double speed_val) {
  * @param cam CAM to set the acceleration value s
  * @param lon_accel longitudinal acceleration to set in m/s^2 as decimal number (braking is negative), if not available use 16.1 m/s^2
  */
-inline void setLongitudinalAcceleration(CAM& cam, const double lon_accel) {
+inline void setLongitudinalAcceleration(CAM& cam, const double lon_accel, const double confidence = AccelerationConfidence::UNAVAILABLE) {
   setLongitudinalAcceleration(
       cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.longitudinal_acceleration,
-      lon_accel);
+      lon_accel, confidence);
 }
 
 /**
@@ -170,10 +170,10 @@ inline void setLongitudinalAcceleration(CAM& cam, const double lon_accel) {
  * @param cam CAM to set the acceleration value s
  * @param lat_accel lateral acceleration to set in m/s^2 as decimal number (left is positiv), if not available use 16.1 m/s^2
  */
-inline void setLateralAcceleration(CAM& cam, const double lat_accel) {
+inline void setLateralAcceleration(CAM& cam, const double lat_accel, const double confidence = AccelerationConfidence::UNAVAILABLE) {
   setLateralAcceleration(
       cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.lateral_acceleration,
-      lat_accel);
+      lat_accel, confidence);
   cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency
       .lateral_acceleration_is_present = true;
 }

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
@@ -84,10 +84,11 @@ inline void setStationType(CAM& cam, const uint8_t value) {
  *
  * @param cam CAM to set the ReferencePosition
  * @param value Heading value in degree as decimal number
+ * @param confidence standard deviation of heading in degree as decimal number (default: infinity, mapping to HeadingConfidence::UNAVAILABLE)
  */
-inline void setHeading(CAM& cam, const double heading_val) {
+inline void setHeading(CAM& cam, const double heading_val, const double confidence = std::numeric_limits<double>::infinity()) {
   setHeadingCDD(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.heading,
-             heading_val);
+             heading_val, confidence);
 }
 
 /**

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_ts_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_ts_getters.h
@@ -45,7 +45,7 @@ namespace etsi_its_cam_ts_msgs::access {
  * @param cam The CAM message to get the reference position from
  * @return const std::array<double, 4> the covariance matrix, as specified above
  */
-inline const std::array<double, 4> getRefPosConfidence(CAM& cam) {
+inline const std::array<double, 4> getRefPosConfidence(const CAM& cam) {
   double object_heading = getHeading(cam) * M_PI / 180.0;
   return getPositionConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse, object_heading);
 }
@@ -59,7 +59,7 @@ inline const std::array<double, 4> getRefPosConfidence(CAM& cam) {
  * @param cam The CAM message to get the reference position from
  * @return const std::array<double, 4> the covariance matrix, as specified above
  */
-inline const std::array<double, 4> getWGSRefPosConfidence(CAM& cam) {
+inline const std::array<double, 4> getWGSRefPosConfidence(const CAM& cam) {
   return getWGSPositionConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse);
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_ts_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_ts_getters.h
@@ -46,8 +46,21 @@ namespace etsi_its_cam_ts_msgs::access {
  * @return const std::array<double, 4> the covariance matrix, as specified above
  */
 inline const std::array<double, 4> getRefPosConfidence(CAM& cam) {
-    double object_heading = getHeading(cam) * M_PI / 180.0;
-    return getPositionConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse, object_heading);
-  }
+  double object_heading = getHeading(cam) * M_PI / 180.0;
+  return getPositionConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse, object_heading);
+}
+
+/**
+ * @brief Get the confidence ellipse of the reference position as Covariance matrix
+ * 
+ * The covariance matrix will have the entries cov_xx, cov_xy, cov_yx, cov_yy
+ * where x is WGS84 North and y is East
+ * 
+ * @param cam The CAM message to get the reference position from
+ * @return const std::array<double, 4> the covariance matrix, as specified above
+ */
+inline const std::array<double, 4> getWGSRefPosConfidence(CAM& cam) {
+  return getWGSPositionConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse);
+}
 
 }  // namespace etsi_its_cam_ts_msgs::access

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_ts_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_ts_getters.h
@@ -36,6 +36,15 @@ namespace etsi_its_cam_ts_msgs::access {
 
 #include <etsi_its_msgs_utils/impl/cam/cam_getters_common.h>
 
+/**
+ * @brief Get the confidence ellipse of the reference position as Covariance matrix
+ * 
+ * The covariance matrix will have the entries cov_xx, cov_xy, cov_yx, cov_yy
+ * where x is the longitudinal axis and y is the lateral axis of the vehicle.
+ * 
+ * @param cam The CAM message to get the reference position from
+ * @return const std::array<double, 4> the covariance matrix, as specified above
+ */
 inline const std::array<double, 4> getRefPosConfidence(CAM& cam) {
     double object_heading = getHeading(cam) * M_PI / 180.0;
     return getPositionConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse, object_heading);

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_ts_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_ts_getters.h
@@ -35,4 +35,10 @@ namespace etsi_its_cam_ts_msgs::access {
 #include <etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h>
 
 #include <etsi_its_msgs_utils/impl/cam/cam_getters_common.h>
+
+inline const std::array<double, 4> getRefPosConfidence(CAM& cam) {
+    double object_heading = getHeading(cam) * M_PI / 180.0;
+    return getPositionConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse, object_heading);
+  }
+
 }  // namespace etsi_its_cam_ts_msgs::access

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_ts_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_ts_setters.h
@@ -73,4 +73,18 @@ inline void setRefPosConfidence(CAM& cam, const std::array<double, 4>& covarianc
                           covariance_matrix, object_heading);
 }
 
+/**
+ * @brief Set the confidence of the reference position
+ * 
+ * @param cam CAM-Message to set the confidence
+ * @param covariance_matrix The four values of the covariance matrix in the order: cov_xx, cov_xy, cov_yx, cov_yy
+ *                          The matrix has to be SPD, otherwise a std::invalid_argument exception is thrown.
+ *                          Its coordinate system is WGS84 (x = North, y = East)
+ */
+inline void setWGSRefPosConfidence(CAM& cam, const std::array<double, 4>& covariance_matrix) {
+  setWGSPositionConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse,
+                                  covariance_matrix);
+}
+
+
 }  // namespace etsi_its_cam_ts_msgs::access

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_ts_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_ts_setters.h
@@ -48,4 +48,29 @@ inline void setItsPduHeader(CAM& cam, const uint32_t station_id, const uint8_t p
   setItsPduHeader(cam.header, MessageId::CAM, station_id, protocol_version);
 }
 
+/**
+ * @brief Set the confidence of the reference position
+ * 
+ * @param cam CAM-Message to set the confidence
+ * @param covariance_matrix The four values of the covariance matrix in the order: cov_xx, cov_xy, cov_yx, cov_yy
+ *                          The matrix has to be SPD, otherwise a std::invalid_argument exception is thrown.
+ *                          Its coordinate system is aligned with the object (x = longitudinal, y = lateral)
+ * @param object_heading heading of the object in rad, with respect to WGS84
+ */
+inline void setRefPosConfidence(CAM& cam, const std::array<double, 4>& covariance_matrix, const double object_heading) {
+  // First ensure, that the object has the correct heading by setting its value
+  double orientation = object_heading * 180 / M_PI; // Convert to degrees
+  // Normalize to [0, 360)
+  orientation = std::fmod(orientation + 360, 360);
+  while (orientation < 0) {
+    orientation += 360;
+  }
+  while (orientation >= 360) {
+    orientation -= 360;
+  }
+  setHeading(cam, orientation);
+  setPositionConfidenceEllipse(cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse,
+                          covariance_matrix, object_heading);
+}
+
 }  // namespace etsi_its_cam_ts_msgs::access

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
@@ -77,6 +77,10 @@ inline double getAltitude(const Altitude& altitude) { return ((double)altitude.a
  */
 inline double getSpeed(const Speed& speed) { return ((double)speed.speed_value.value) * 1e-2; }
 
+inline double getSpeedConfidence(const Speed& speed) {
+  return ((double)speed.speed_confidence.value) / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR * 1e-2;
+}
+
 /**
  * @brief Get the UTM Position defined by the given ReferencePosition
  *

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
@@ -77,6 +77,12 @@ inline double getAltitude(const Altitude& altitude) { return ((double)altitude.a
  */
 inline double getSpeed(const Speed& speed) { return ((double)speed.speed_value.value) * 1e-2; }
 
+/**
+ * @brief Get the Speed Confidence 
+ * 
+ * @param speed to get the SpeedConfidence from
+ * @return double speed standard deviation in m/s as decimal number
+ */
 inline double getSpeedConfidence(const Speed& speed) {
   return ((double)speed.speed_confidence.value) / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR * 1e-2;
 }
@@ -122,7 +128,7 @@ inline gm::PointStamped getUTMPosition(const T& reference_position, int& zone, b
  * @return Heading value in degree as decimal number
  */
 template <typename Heading>
-inline double getHeadingInternal(const Heading& heading) { return ((double)heading.heading_value.value) * 1e-1; }
+inline double getHeadingCDD(const Heading& heading) { return ((double)heading.heading_value.value) * 1e-1; }
 
 /**
  * @brief Get the Semi Axis object
@@ -131,7 +137,7 @@ inline double getHeadingInternal(const Heading& heading) { return ((double)headi
  * @return double the semi axis length in meters
  */
 template <typename SemiAxisLength>
-inline double getSemiAxis(SemiAxisLength& semi_axis_length) {
+inline double getSemiAxis(const SemiAxisLength& semi_axis_length) {
   return ((double)semi_axis_length.value) * 1e-2 / etsi_its_msgs::OneCentimeterHelper<SemiAxisLength>::value;
 }
 
@@ -142,7 +148,7 @@ inline double getSemiAxis(SemiAxisLength& semi_axis_length) {
  * @return std::tuple<double, double, double> major axis length in meters, minor axis length in meters, and orientation in degrees
  */
 template <typename PosConfidenceEllipse>
-inline std::tuple<double, double, double> getPosConfidenceEllipse(PosConfidenceEllipse& position_confidence_ellipse) {
+inline std::tuple<double, double, double> getPosConfidenceEllipse(const PosConfidenceEllipse& position_confidence_ellipse) {
   return {
     getSemiAxis(position_confidence_ellipse.semi_major_confidence),
     getSemiAxis(position_confidence_ellipse.semi_minor_confidence),

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
@@ -131,6 +131,17 @@ template <typename Heading>
 inline double getHeadingCDD(const Heading& heading) { return ((double)heading.heading_value.value) * 1e-1; }
 
 /**
+ * @brief Get the Heading value
+ *
+ * 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West
+ *
+ * @param heading to get the Heading standard deviation from
+ * @return Heading standard deviation in degree as decimal number
+ */
+template <typename Heading>
+inline double getHeadingConfidenceCDD(const Heading& heading) { return ((double)heading.heading_confidence.value) * 1e-1 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR; }
+
+/**
  * @brief Get the Semi Axis object
  * 
  * @param semi_axis_length The SemiAxisLength object to get the semi axis from

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
@@ -155,7 +155,7 @@ inline std::tuple<double, double, double> getPosConfidenceEllipse(PosConfidenceE
  * @param semi_minor Semi minor axis length in meters
  * @param major_orientation Orientation of the major axis in degrees, relative to WGS84
  * @param object_heading object heading in radians, relative to WGS84
- * @return std::array<double, 4> 
+ * @return std::array<double, 4> The covariance matrix in vehicle coordinates (x = longitudinal, y = lateral)
  */
 inline std::array<double, 4> CovMatrixFromConfidenceEllipse(double semi_major, double semi_minor, double major_orientation, const double object_heading) {
   std::array<double, 4> covariance_matrix;
@@ -177,16 +177,44 @@ inline std::array<double, 4> CovMatrixFromConfidenceEllipse(double semi_major, d
 }
 
 /**
+ * @brief Convert the confidence ellipse to a covariance matrix
+ * 
+ * Note that the major_orientation is given in degrees, while the object_heading is given in radians!
+ * 
+ * @param semi_major Semi major axis length in meters
+ * @param semi_minor Semi minor axis length in meters
+ * @param major_orientation Orientation of the major axis in degrees, relative to WGS84
+ * @return std::array<double, 4> The covariance matrix in WGS coordinates (x = North, y = East)
+ */
+inline std::array<double, 4> WGSCovMatrixFromConfidenceEllipse(double semi_major, double semi_minor, double major_orientation) {
+  // The WGS covariance matrix is the same as in vehicle coordinates, if it would have a heading of 0.0
+  return CovMatrixFromConfidenceEllipse(semi_major, semi_minor, major_orientation, 0.0);
+}
+
+/**
  * @brief Get the covariance matrix of the position confidence ellipse
  * 
  * @param position_confidence_ellipse The position confidence ellipse to get the covariance matrix from
  * @param object_heading The object heading in radians
- * @return std::array<double, 4> The covariance matrix of the position confidence ellipse
+ * @return std::array<double, 4> The covariance matrix of the position confidence ellipse in vehicle coordinates (x = longitudinal, y = lateral)
  */
 template <typename PosConfidenceEllipse>
 inline std::array<double, 4> getPosConfidenceEllipse(const PosConfidenceEllipse& position_confidence_ellipse, const double object_heading){
   auto [semi_major, semi_minor, major_orientation] = getPosConfidenceEllipse(position_confidence_ellipse);
   return CovMatrixFromConfidenceEllipse(semi_major, semi_minor, major_orientation, object_heading);
+}
+
+/**
+ * @brief Get the covariance matrix of the position confidence ellipse
+ * 
+ * @param position_confidence_ellipse The position confidence ellipse to get the covariance matrix from
+ * @param object_heading The object heading in radians
+ * @return std::array<double, 4> The covariance matrix of the position confidence ellipse in WGS coordinates (x = North, y = East)
+ */
+template <typename PosConfidenceEllipse>
+inline std::array<double, 4> getWGSPosConfidenceEllipse(const PosConfidenceEllipse& position_confidence_ellipse){
+  auto [semi_major, semi_minor, major_orientation] = getPosConfidenceEllipse(position_confidence_ellipse);
+  return WGSCovMatrixFromConfidenceEllipse(semi_major, semi_minor, major_orientation);
 }
 
 #endif  // ETSI_ITS_MSGS_UTILS_IMPL_CDD_CDD_GETTERS_COMMON_H

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
@@ -120,11 +120,23 @@ inline gm::PointStamped getUTMPosition(const T& reference_position, int& zone, b
 template <typename Heading>
 inline double getHeadingInternal(const Heading& heading) { return ((double)heading.heading_value.value) * 1e-1; }
 
+/**
+ * @brief Get the Semi Axis object
+ * 
+ * @param semi_axis_length The SemiAxisLength object to get the semi axis from
+ * @return double the semi axis length in meters
+ */
 template <typename SemiAxisLength>
 inline double getSemiAxis(SemiAxisLength& semi_axis_length) {
   return ((double)semi_axis_length.value) * 1e-2 / etsi_its_msgs::OneCentimeterHelper<SemiAxisLength>::value;
 }
 
+/**
+ * @brief Extract major axis length, minor axis length and orientation from the given position confidence ellipse
+ * 
+ * @param position_confidence_ellipse The position confidence ellipse to extract the values from
+ * @return std::tuple<double, double, double> major axis length in meters, minor axis length in meters, and orientation in degrees
+ */
 template <typename PosConfidenceEllipse>
 inline std::tuple<double, double, double> getPosConfidenceEllipse(PosConfidenceEllipse& position_confidence_ellipse) {
   return {
@@ -134,6 +146,17 @@ inline std::tuple<double, double, double> getPosConfidenceEllipse(PosConfidenceE
   };
 }
 
+/**
+ * @brief Convert the confidence ellipse to a covariance matrix
+ * 
+ * Note that the major_orientation is given in degrees, while the object_heading is given in radians!
+ * 
+ * @param semi_major Semi major axis length in meters
+ * @param semi_minor Semi minor axis length in meters
+ * @param major_orientation Orientation of the major axis in degrees, relative to WGS84
+ * @param object_heading object heading in radians, relative to WGS84
+ * @return std::array<double, 4> 
+ */
 inline std::array<double, 4> CovMatrixFromConfidenceEllipse(double semi_major, double semi_minor, double major_orientation, const double object_heading) {
   std::array<double, 4> covariance_matrix;
   double semi_major_squared = semi_major * semi_major / (etsi_its_msgs::TWO_D_GAUSSIAN_FACTOR * etsi_its_msgs::TWO_D_GAUSSIAN_FACTOR);
@@ -153,7 +176,13 @@ inline std::array<double, 4> CovMatrixFromConfidenceEllipse(double semi_major, d
   return covariance_matrix;
 }
 
-
+/**
+ * @brief Get the covariance matrix of the position confidence ellipse
+ * 
+ * @param position_confidence_ellipse The position confidence ellipse to get the covariance matrix from
+ * @param object_heading The object heading in radians
+ * @return std::array<double, 4> The covariance matrix of the position confidence ellipse
+ */
 template <typename PosConfidenceEllipse>
 inline std::array<double, 4> getPosConfidenceEllipse(const PosConfidenceEllipse& position_confidence_ellipse, const double object_heading){
   auto [semi_major, semi_minor, major_orientation] = getPosConfidenceEllipse(position_confidence_ellipse);

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
@@ -121,7 +121,7 @@ template <typename Heading>
 inline double getHeadingInternal(const Heading& heading) { return ((double)heading.heading_value.value) * 1e-1; }
 
 template <typename SemiAxisLength>
-inline double getSemiAxis(SemiAxisLength& semi_axis_length, const double length) {
+inline double getSemiAxis(SemiAxisLength& semi_axis_length) {
   return ((double)semi_axis_length.value) * 1e-2 / etsi_its_msgs::OneCentimeterHelper<SemiAxisLength>::value;
 }
 
@@ -130,7 +130,7 @@ inline std::tuple<double, double, double> getPosConfidenceEllipse(PosConfidenceE
   return {
     getSemiAxis(position_confidence_ellipse.semi_major_confidence),
     getSemiAxis(position_confidence_ellipse.semi_minor_confidence),
-    getHeadingValue(position_confidence_ellipse.semi_major_orientation)
+    position_confidence_ellipse.semi_major_orientation.value * 1e-1
   };
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
@@ -220,7 +220,14 @@ void setHeadingInternal(Heading& heading, const double value) {
   setHeadingValue(heading.heading_value, value);
 }
 
-// See https://godbolt.org/z/Eceavfo99
+/**
+ * @brief Set the Semi Axis length
+ * 
+ * // See https://godbolt.org/z/Eceavfo99 on how the OneCentimeterHelper works with this template
+ * 
+ * @param semi_axis_length The SemiAxisLength to set
+ * @param length the desired length in meters
+ */
 template <typename SemiAxisLength>
 inline void setSemiAxis(SemiAxisLength& semi_axis_length, const double length) {
   double semi_axis_length_val = std::round(length * etsi_its_msgs::OneCentimeterHelper<SemiAxisLength>::value * 1e2);

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
@@ -286,10 +286,6 @@ inline std::tuple<double, double, double> confidenceEllipseFromCovMatrix(const s
   double semi_minor_axis = std::sqrt(eigenvalue2) * etsi_its_msgs::TWO_D_GAUSSIAN_FACTOR;
   // object_heading - orientation of the ellipse, as WGS84 has positive angles to the right
   double orientation = object_heading - 0.5 * std::atan2(2 * covariance_matrix[1], covariance_matrix[0] - covariance_matrix[3]);
-  std::cerr << "Covariance matrix: " << std::endl;
-  std::cerr << covariance_matrix[0] << " " << covariance_matrix[1] << std::endl;
-  std::cerr << covariance_matrix[2] << " " << covariance_matrix[3] << std::endl;
-  std::cerr << "Internal orientation: " << 0.5 * std::atan2(2 * covariance_matrix[1], covariance_matrix[0] - covariance_matrix[3]) << std::endl;
   orientation = orientation * 180 / M_PI; // Convert to degrees
   // Normalize to [0, 180)
   // Not to 0, 360, as the ellipse is symmetric and the orientation is defined as the angle between the semi-major axis and the x-axis

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
@@ -297,6 +297,21 @@ inline std::tuple<double, double, double> confidenceEllipseFromCovMatrix(const s
 }
 
 /**
+ * @brief Gets the values needed to set a confidence ellipse from a covariance matrix.
+ * 
+ * @param covariance_matrix The four values of the covariance matrix in the order: cov_xx, cov_xy, cov_yx, cov_yy
+ *                          The matrix has to be SPD, otherwise a std::invalid_argument exception is thrown.
+ *                          Its coordinate system is aligned with the WGS axes (x = North, y = East)
+ * @param object_heading The heading of the object in rad, with respect to WGS84
+ * @return std::tuple<double, double, double> semi_major_axis [m], semi_minor_axis [m], orientation [deg], with respect to WGS84
+ */
+inline std::tuple<double, double, double> confidenceEllipseFromWGSCovMatrix(const std::array<double, 4>& covariance_matrix) {
+  // The resulting ellipse is the same as if the cov matrix was given in vehicle coordinates
+  // and the object heading was set to 0.0
+  return confidenceEllipseFromCovMatrix(covariance_matrix, 0.0);
+}
+
+/**
  * @brief Set the Pos Confidence Ellipse object
  * 
  * @param position_confidence_ellipse 
@@ -310,6 +325,22 @@ inline void setPosConfidenceEllipse(PosConfidenceEllipse& position_confidence_el
   auto [semi_major_axis, semi_minor_axis, orientation] = confidenceEllipseFromCovMatrix(covariance_matrix, object_heading);
   setPosConfidenceEllipse(position_confidence_ellipse, semi_major_axis, semi_minor_axis, orientation);
 }
+
+/**
+ * @brief Set the Pos Confidence Ellipse object
+ * 
+ * @param position_confidence_ellipse 
+ * @param covariance_matrix The four values of the covariance matrix in the order: cov_xx, cov_xy, cov_yx, cov_yy
+ *                          The matrix has to be SPD, otherwise a std::invalid_argument exception is thrown.
+ *                          Its coordinate system is aligned with the WGS axes (x = North, y = East)
+ * @param object_heading The heading of the object in rad, with respect to WGS84
+ */
+template <typename PosConfidenceEllipse>
+inline void setWGSPosConfidenceEllipse(PosConfidenceEllipse& position_confidence_ellipse, const std::array<double, 4>& covariance_matrix){
+  auto [semi_major_axis, semi_minor_axis, orientation] = confidenceEllipseFromWGSCovMatrix(covariance_matrix);
+  setPosConfidenceEllipse(position_confidence_ellipse, semi_major_axis, semi_minor_axis, orientation);
+}
+
 
 
 #endif  // ETSI_ITS_MSGS_UTILS_IMPL_CDD_CDD_SETTERS_COMMON_H

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
@@ -220,20 +220,10 @@ void setHeadingInternal(Heading& heading, const double value) {
   setHeadingValue(heading.heading_value, value);
 }
 
-template <typename SemiAxisLength, typename = std::void_t<>>
-struct OneCentimeterHelper {
-    static constexpr int value = 1; // Default value
-};
-
-template <typename SemiAxisLength>
-struct OneCentimeterHelper<SemiAxisLength, std::void_t<decltype(SemiAxisLength::ONE_CENTIMETER)>> {
-    static constexpr int value = SemiAxisLength::ONE_CENTIMETER;
-};
-
 // See https://godbolt.org/z/Eceavfo99
 template <typename SemiAxisLength>
 inline void setSemiAxis(SemiAxisLength& semi_axis_length, const double length) {
-  double semi_axis_length_val = std::round(length * OneCentimeterHelper<SemiAxisLength>::value * 1e2);
+  double semi_axis_length_val = std::round(length * etsi_its_msgs::OneCentimeterHelper<SemiAxisLength>::value * 1e2);
   if(semi_axis_length_val < 1) {
     semi_axis_length_val = SemiAxisLength::UNAVAILABLE;
   } else if(semi_axis_length_val >= SemiAxisLength::OUT_OF_RANGE) {

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
@@ -123,6 +123,12 @@ inline void setSpeedValue(SpeedValue& speed, const double value) {
   speed.value = static_cast<decltype(speed.value)>(speed_val);
 }
 
+/**
+ * @brief Set the Speed Confidence object
+ * 
+ * @param speed_confidence object to set
+ * @param value standard deviation in m/s as decimal number
+ */
 inline void setSpeedConfidence(SpeedConfidence& speed_confidence, const double value) {
   auto speed_conf = std::round(value * 1e2 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   if (speed_conf < SpeedConfidence::MIN && speed_conf > 0.0){
@@ -140,12 +146,19 @@ inline void setSpeedConfidence(SpeedConfidence& speed_confidence, const double v
  *
  * @param speed object to set
  * @param value  Speed in in m/s as decimal number
+ * @param confidence standard deviation in m/s as decimal number (Optional. Default is std::numeric_limits<double>::infinity(), mapping to SpeedConfidence::UNAVAILABLE)
  */
-inline void setSpeed(Speed& speed, const double value, const double confidence = SpeedConfidence::UNAVAILABLE) {
+inline void setSpeed(Speed& speed, const double value, const double confidence = std::numeric_limits<double>::infinity()) {
   setSpeedConfidence(speed.speed_confidence, confidence);
   setSpeedValue(speed.speed_value, value);
 }
 
+/**
+ * @brief Set the Acceleration Confidence object
+ * 
+ * @param accel_confidence object to set
+ * @param value standard deviation in m/s^2 as decimal number
+ */
 template <typename AccelerationConfidence>
 inline void setAccelerationConfidence(AccelerationConfidence& accel_confidence, const double value) {
   auto accel_conf = std::round(value * 1e1 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
@@ -249,7 +249,7 @@ inline void setHeadingValue(HeadingValue& heading, const double value) {
  * @param value Heading value in degree as decimal number
  */
 template <typename Heading, typename HeadingConfidence = decltype(Heading::heading_confidence)>
-void setHeadingInternal(Heading& heading, const double value) {
+void setHeadingCDD(Heading& heading, const double value) {
   heading.heading_confidence.value = HeadingConfidence::UNAVAILABLE;
   setHeadingValue(heading.heading_value, value);
 }

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
@@ -240,6 +240,23 @@ inline void setHeadingValue(HeadingValue& heading, const double value) {
 }
 
 /**
+ * @brief Set the Heading Confidence object
+ * 
+ * @param heading_confidence object to set
+ * @param value standard deviation of heading in degree as decimal number
+ */
+template<typename HeadingConfidence>
+inline void setHeadingConfidence(HeadingConfidence& heading_confidence, const double value) {
+  auto heading_conf = std::round(value * 1e1 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+  if (heading_conf < HeadingConfidence::MIN && heading_conf > 0.0){
+    heading_conf = HeadingConfidence::MIN;
+  } else if (heading_conf >= HeadingConfidence::OUT_OF_RANGE || heading_conf <= 0.0) {
+    heading_conf = HeadingConfidence::UNAVAILABLE;
+  }
+  heading_confidence.value = static_cast<decltype(heading_confidence.value)>(heading_conf);
+}
+
+/**
  * @brief Set the Heading object
  *
  * 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West
@@ -247,10 +264,11 @@ inline void setHeadingValue(HeadingValue& heading, const double value) {
  *
  * @param heading object to set
  * @param value Heading value in degree as decimal number
+ * @param confidence standard deviation of heading in degree as decimal number (default: infinity, mapping to HeadingConfidence::UNAVAILABLE) 
  */
 template <typename Heading, typename HeadingConfidence = decltype(Heading::heading_confidence)>
-void setHeadingCDD(Heading& heading, const double value) {
-  heading.heading_confidence.value = HeadingConfidence::UNAVAILABLE;
+void setHeadingCDD(Heading& heading, const double value, double confidence = std::numeric_limits<double>::infinity()) {
+  setHeadingConfidence(heading.heading_confidence, confidence);
   setHeadingValue(heading.heading_value, value);
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h
@@ -46,6 +46,12 @@ inline double getLongitudinalAcceleration(const AccelerationComponent& longitudi
   return ((double)longitudinal_acceleration.value.value) * 1e-1;
 }
 
+/**
+ * @brief Get the Longitudinal Acceleration Confidence
+ * 
+ * @param longitudinal_acceleration to get the LongitudinalAccelerationConfidence from
+ * @return double standard deviation of the longitudinal acceleration in m/s^2 as decimal number
+ */
 inline double getLongitudinalAccelerationConfidence(const AccelerationComponent& longitudinal_acceleration) {
   return ((double)longitudinal_acceleration.confidence.value) * 1e-1 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
 }
@@ -60,6 +66,12 @@ inline double getLateralAcceleration(const AccelerationComponent& lateral_accele
   return ((double)lateral_acceleration.value.value) * 1e-1;
 }
 
+/**
+ * @brief Get the Lateral Acceleration Confidence
+ * 
+ * @param lateral_acceleration to get the LateralAccelerationConfidence from
+ * @return double standard deviation of the lateral acceleration in m/s^2 as decimal number
+ */
 inline double getLateralAccelerationConfidence(const AccelerationComponent& lateral_acceleration) {
   return ((double)lateral_acceleration.confidence.value) * 1e-1 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
 }

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h
@@ -77,12 +77,26 @@ inline std::tuple<double, double, double> getPositionConfidenceEllipse(PositionC
  * 
  * @param position_confidence_ellipse The position confidence ellipse to get the covariance matrix from
  * @param object_heading The object heading in radians
- * @return std::array<double, 4> The covariance matrix of the position confidence ellipse
+ * @return std::array<double, 4> The covariance matrix of the position confidence ellipse in vehicle coordinates (x = longitudinal, y = lateral)
  */
 template <typename PositionConfidenceEllipse>
 inline std::array<double, 4> getPositionConfidenceEllipse(const PositionConfidenceEllipse& position_confidence_ellipse, const double object_heading){
   auto [semi_major, semi_minor, major_orientation] = getPositionConfidenceEllipse(position_confidence_ellipse);
   return CovMatrixFromConfidenceEllipse(semi_major, semi_minor, major_orientation, object_heading);
 }
+
+/**
+ * @brief Get the covariance matrix of the position confidence ellipse
+ * 
+ * @param position_confidence_ellipse The position confidence ellipse to get the covariance matrix from
+ * @param object_heading The object heading in radians
+ * @return std::array<double, 4> The covariance matrix of the position confidence ellipse in WGS coordinates (x = North, y = East)
+ */
+template <typename PositionConfidenceEllipse>
+inline std::array<double, 4> getWGSPositionConfidenceEllipse(const PositionConfidenceEllipse& position_confidence_ellipse){
+  auto [semi_major, semi_minor, major_orientation] = getPositionConfidenceEllipse(position_confidence_ellipse);
+  return WGSCovMatrixFromConfidenceEllipse(semi_major, semi_minor, major_orientation);
+}
+
 
 #endif  // ETSI_ITS_MSGS_UTILS_IMPL_CDD_CDD_V2_1_1_GETTERS_H

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h
@@ -56,4 +56,20 @@ inline double getLateralAcceleration(const AccelerationComponent& lateral_accele
   return ((int16_t)lateral_acceleration.value.value) * 1e-1;
 }
 
+template <typename PositionConfidenceEllipse>
+inline std::tuple<double, double, double> getPositionConfidenceEllipse(PositionConfidenceEllipse& position_confidence_ellipse) {
+  return {
+    getSemiAxis(position_confidence_ellipse.semi_major_confidence),
+    getSemiAxis(position_confidence_ellipse.semi_minor_confidence),
+    getHeadingValue(position_confidence_ellipse.semi_major_orientation)
+  };
+}
+
+
+template <typename PositionConfidenceEllipse>
+inline std::array<double, 4> getPositionConfidenceEllipse(const PositionConfidenceEllipse& position_confidence_ellipse, const double object_heading){
+  auto [semi_major, semi_minor, major_orientation] = getPositionConfidenceEllipse(position_confidence_ellipse);
+  return CovMatrixFromConfidenceEllipse(semi_major, semi_minor, major_orientation, object_heading);
+}
+
 #endif  // ETSI_ITS_MSGS_UTILS_IMPL_CDD_CDD_V2_1_1_GETTERS_H

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h
@@ -56,6 +56,13 @@ inline double getLateralAcceleration(const AccelerationComponent& lateral_accele
   return ((int16_t)lateral_acceleration.value.value) * 1e-1;
 }
 
+
+/**
+ * @brief Extract major axis length, minor axis length and orientation from the given position confidence ellipse
+ * 
+ * @param position_confidence_ellipse The position confidence ellipse to extract the values from
+ * @return std::tuple<double, double, double> major axis length in meters, minor axis length in meters, and orientation in degrees
+ */
 template <typename PositionConfidenceEllipse>
 inline std::tuple<double, double, double> getPositionConfidenceEllipse(PositionConfidenceEllipse& position_confidence_ellipse) {
   return {
@@ -65,7 +72,13 @@ inline std::tuple<double, double, double> getPositionConfidenceEllipse(PositionC
   };
 }
 
-
+/**
+ * @brief Get the covariance matrix of the position confidence ellipse
+ * 
+ * @param position_confidence_ellipse The position confidence ellipse to get the covariance matrix from
+ * @param object_heading The object heading in radians
+ * @return std::array<double, 4> The covariance matrix of the position confidence ellipse
+ */
 template <typename PositionConfidenceEllipse>
 inline std::array<double, 4> getPositionConfidenceEllipse(const PositionConfidenceEllipse& position_confidence_ellipse, const double object_heading){
   auto [semi_major, semi_minor, major_orientation] = getPositionConfidenceEllipse(position_confidence_ellipse);

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h
@@ -43,7 +43,11 @@ SOFTWARE.
  * @return longitudinal acceleration in m/s^2 as decimal number (left is positive)
  */
 inline double getLongitudinalAcceleration(const AccelerationComponent& longitudinal_acceleration) {
-  return ((int16_t)longitudinal_acceleration.value.value) * 1e-1;
+  return ((double)longitudinal_acceleration.value.value) * 1e-1;
+}
+
+inline double getLongitudinalAccelerationConfidence(const AccelerationComponent& longitudinal_acceleration) {
+  return ((double)longitudinal_acceleration.confidence.value) * 1e-1 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
 }
 
 /**
@@ -53,7 +57,11 @@ inline double getLongitudinalAcceleration(const AccelerationComponent& longitudi
  * @return lateral acceleration in m/s^2 as decimal number (left is positive)
  */
 inline double getLateralAcceleration(const AccelerationComponent& lateral_acceleration) {
-  return ((int16_t)lateral_acceleration.value.value) * 1e-1;
+  return ((double)lateral_acceleration.value.value) * 1e-1;
+}
+
+inline double getLateralAccelerationConfidence(const AccelerationComponent& lateral_acceleration) {
+  return ((double)lateral_acceleration.confidence.value) * 1e-1 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
 }
 
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h
@@ -59,9 +59,9 @@ inline double getLateralAcceleration(const AccelerationComponent& lateral_accele
 template <typename PositionConfidenceEllipse>
 inline std::tuple<double, double, double> getPositionConfidenceEllipse(PositionConfidenceEllipse& position_confidence_ellipse) {
   return {
-    getSemiAxis(position_confidence_ellipse.semi_major_confidence),
-    getSemiAxis(position_confidence_ellipse.semi_minor_confidence),
-    getHeadingValue(position_confidence_ellipse.semi_major_orientation)
+    getSemiAxis(position_confidence_ellipse.semi_major_axis_length),
+    getSemiAxis(position_confidence_ellipse.semi_minor_axis_length),
+    position_confidence_ellipse.semi_major_axis_orientation.value * 1e-1
   };
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_setters.h
@@ -101,8 +101,8 @@ inline void setLongitudinalAccelerationValue(AccelerationValue& accel, const dou
  * @param accel object to set
  * @param value LongitudinalAccelerationValue in m/s^2 as decimal number (braking is negative)
  */
-inline void setLongitudinalAcceleration(AccelerationComponent& accel, const double value) {
-  accel.confidence.value = AccelerationConfidence::UNAVAILABLE;
+inline void setLongitudinalAcceleration(AccelerationComponent& accel, const double value, const double confidence) {
+  setAccelerationConfidence(accel.confidence, confidence);
   setLongitudinalAccelerationValue(accel.value, value);
 }
 
@@ -131,8 +131,8 @@ inline void setLateralAccelerationValue(AccelerationValue& accel, const double v
  * @param accel object to set
  * @param value LaterallAccelerationValue in m/s^2 as decimal number (left is positive)
  */
-inline void setLateralAcceleration(AccelerationComponent& accel, const double value) {
-  accel.confidence.value = AccelerationConfidence::UNAVAILABLE;
+inline void setLateralAcceleration(AccelerationComponent& accel, const double value, const double confidence) {
+  setAccelerationConfidence(accel.confidence, confidence);
   setLateralAccelerationValue(accel.value, value);
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_setters.h
@@ -136,6 +136,14 @@ inline void setLateralAcceleration(AccelerationComponent& accel, const double va
   setLateralAccelerationValue(accel.value, value);
 }
 
+/**
+ * @brief Set the Position Confidence Ellipse object
+ * 
+ * @param position_confidence_ellipse The position confidence ellipse to set
+ * @param semi_major_axis The length of the semi-major axis in meters
+ * @param semi_minor_axis The length of the semi-minor axis in meters
+ * @param orientation The orientation of the semi-major axis in degrees, relative to WGS84
+ */
 template <typename PositionConfidenceEllipse, typename Wgs84AngleValue = decltype(PositionConfidenceEllipse::semi_major_axis_orientation)>
 inline void setPositionConfidenceEllipse(PositionConfidenceEllipse& position_confidence_ellipse, const double semi_major_axis,
   const double semi_minor_axis, const double orientation) {

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_setters.h
@@ -136,4 +136,28 @@ inline void setLateralAcceleration(AccelerationComponent& accel, const double va
   setLateralAccelerationValue(accel.value, value);
 }
 
+template <typename PositionConfidenceEllipse, typename Wgs84AngleValue = decltype(PositionConfidenceEllipse::semi_major_axis_orientation)>
+inline void setPositionConfidenceEllipse(PositionConfidenceEllipse& position_confidence_ellipse, const double semi_major_axis,
+  const double semi_minor_axis, const double orientation) {
+  setSemiAxis(position_confidence_ellipse.semi_major_axis_length, semi_major_axis);
+  setSemiAxis(position_confidence_ellipse.semi_minor_axis_length, semi_minor_axis);
+  setHeadingValue(position_confidence_ellipse.semi_major_axis_orientation, orientation);
+}
+
+/**
+ * @brief Set the Pos Confidence Ellipse object
+ * 
+ * @param position_confidence_ellipse 
+ * @param covariance_matrix The four values of the covariance matrix in the order: cov_xx, cov_xy, cov_yx, cov_yy
+ *                          The matrix has to be SPD, otherwise a std::invalid_argument exception is thrown.
+ *                          The type needs to have an operator[] that resturns values of type double for at least indices 0-3.
+ *                          Possibilities include std::array<double, 4>, std::vector<double>, double*, ...
+ * @param object_heading The heading of the object in rad, with respect to WGS84
+ */
+template <typename PositionConfidenceEllipse>
+inline void setPositionConfidenceEllipse(PositionConfidenceEllipse& position_confidence_ellipse, const std::array<double, 4>& covariance_matrix, const double object_heading){
+  auto [semi_major_axis, semi_minor_axis, orientation] = confidenceEllipseFromCovMatrix(covariance_matrix, object_heading);
+  setPositionConfidenceEllipse(position_confidence_ellipse, semi_major_axis, semi_minor_axis, orientation);
+}
+
 #endif  // ETSI_ITS_MSGS_UTILS_IMPL_CDD_CDD_V2_1_1_SETTERS_H

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_setters.h
@@ -150,8 +150,7 @@ inline void setPositionConfidenceEllipse(PositionConfidenceEllipse& position_con
  * @param position_confidence_ellipse 
  * @param covariance_matrix The four values of the covariance matrix in the order: cov_xx, cov_xy, cov_yx, cov_yy
  *                          The matrix has to be SPD, otherwise a std::invalid_argument exception is thrown.
- *                          The type needs to have an operator[] that resturns values of type double for at least indices 0-3.
- *                          Possibilities include std::array<double, 4>, std::vector<double>, double*, ...
+ *                          Its coordinate system is aligned with the object (x = longitudinal, y = lateral)
  * @param object_heading The heading of the object in rad, with respect to WGS84
  */
 template <typename PositionConfidenceEllipse>

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_setters.h
@@ -153,7 +153,7 @@ inline void setPositionConfidenceEllipse(PositionConfidenceEllipse& position_con
 }
 
 /**
- * @brief Set the Pos Confidence Ellipse object
+ * @brief Set the Position Confidence Ellipse object
  * 
  * @param position_confidence_ellipse 
  * @param covariance_matrix The four values of the covariance matrix in the order: cov_xx, cov_xy, cov_yx, cov_yy
@@ -164,6 +164,21 @@ inline void setPositionConfidenceEllipse(PositionConfidenceEllipse& position_con
 template <typename PositionConfidenceEllipse>
 inline void setPositionConfidenceEllipse(PositionConfidenceEllipse& position_confidence_ellipse, const std::array<double, 4>& covariance_matrix, const double object_heading){
   auto [semi_major_axis, semi_minor_axis, orientation] = confidenceEllipseFromCovMatrix(covariance_matrix, object_heading);
+  setPositionConfidenceEllipse(position_confidence_ellipse, semi_major_axis, semi_minor_axis, orientation);
+}
+
+/**
+ * @brief Set the Position Confidence Ellipse object
+ * 
+ * @param position_confidence_ellipse 
+ * @param covariance_matrix The four values of the covariance matrix in the order: cov_xx, cov_xy, cov_yx, cov_yy
+ *                          The matrix has to be SPD, otherwise a std::invalid_argument exception is thrown.
+ *                          Its coordinate system is aligned with the WGS axes (x = North, y = East)
+ * @param object_heading The heading of the object in rad, with respect to WGS84
+ */
+template <typename PositionConfidenceEllipse>
+inline void setWGSPositionConfidenceEllipse(PositionConfidenceEllipse& position_confidence_ellipse, const std::array<double, 4>& covariance_matrix){
+  auto [semi_major_axis, semi_minor_axis, orientation] = confidenceEllipseFromWGSCovMatrix(covariance_matrix);
   setPositionConfidenceEllipse(position_confidence_ellipse, semi_major_axis, semi_minor_axis, orientation);
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/constants.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/constants.h
@@ -67,6 +67,9 @@ inline uint16_t getLeapSecondInsertionsSince2004(const uint64_t unix_seconds) {
   return it->second;  // Return the corresponding value
 }
 
+// An interval containing 95% of the points in a 1D Gaussian distribution
+constexpr const double ONE_D_GAUSSIAN_FACTOR = 2.0;
+
 // An ellipse containing 95% of the points in a 2D Gaussian distribution
 // has size 2.4477*sigma_{major/minor}
 constexpr const double TWO_D_GAUSSIAN_FACTOR = 2.4477;

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/constants.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/constants.h
@@ -67,4 +67,8 @@ inline uint16_t getLeapSecondInsertionsSince2004(const uint64_t unix_seconds) {
   return it->second;  // Return the corresponding value
 }
 
+// An ellipse containing 95% of the points in a 2D Gaussian distribution
+// has size 2.4477*sigma_{major/minor}
+constexpr const double TWO_D_GAUSSIAN_FACTOR = 2.4477;
+
 }  // namespace etsi_its_msgs

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/constants.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/constants.h
@@ -71,11 +71,15 @@ inline uint16_t getLeapSecondInsertionsSince2004(const uint64_t unix_seconds) {
 // has size 2.4477*sigma_{major/minor}
 constexpr const double TWO_D_GAUSSIAN_FACTOR = 2.4477;
 
+
+// Helper struct to get the value of ONE_CENTIMETER from a given type, if it exists
+// Otherwise, it defaults to 1
 template <typename SemiAxisLength, typename = std::void_t<>>
 struct OneCentimeterHelper {
     static constexpr int value = 1; // Default value
 };
 
+// Specialization for types that have ONE_CENTIMETER defined
 template <typename SemiAxisLength>
 struct OneCentimeterHelper<SemiAxisLength, std::void_t<decltype(SemiAxisLength::ONE_CENTIMETER)>> {
     static constexpr int value = SemiAxisLength::ONE_CENTIMETER;

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/constants.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/constants.h
@@ -71,4 +71,15 @@ inline uint16_t getLeapSecondInsertionsSince2004(const uint64_t unix_seconds) {
 // has size 2.4477*sigma_{major/minor}
 constexpr const double TWO_D_GAUSSIAN_FACTOR = 2.4477;
 
+template <typename SemiAxisLength, typename = std::void_t<>>
+struct OneCentimeterHelper {
+    static constexpr int value = 1; // Default value
+};
+
+template <typename SemiAxisLength>
+struct OneCentimeterHelper<SemiAxisLength, std::void_t<decltype(SemiAxisLength::ONE_CENTIMETER)>> {
+    static constexpr int value = SemiAxisLength::ONE_CENTIMETER;
+};
+
+
 }  // namespace etsi_its_msgs

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_access.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_access.h
@@ -45,6 +45,7 @@ SOFTWARE.
 
 #include <GeographicLib/UTMUPS.hpp>
 
+#include <etsi_its_msgs_utils/impl/constants.h>
 #include <etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h>
 #include <etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h>
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
@@ -513,4 +513,17 @@ inline gm::PointStamped getUTMPositionOfPerceivedObject(const CollectivePercepti
   return utm_position;
 }
 
+/**
+ * @brief Get the confidence ellipse of the reference position as Covariance matrix
+ * 
+ * The covariance matrix will have the entries cov_xx, cov_xy, cov_yx, cov_yy
+ * where x is WGS84 North and y is East
+ * 
+ * @param cpm The CPM message to get the reference position from
+ * @return const std::array<double, 4> the covariance matrix, as specified above
+ */
+inline const std::array<double, 4> getWGSRefPosConfidence(const CollectivePerceptionMessage &cpm) {
+  return getWGSPosConfidenceEllipse(cpm.payload.management_container.reference_position.position_confidence_ellipse);
+}
+
 }  // namespace etsi_its_cpm_ts_msgs::access

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
@@ -31,6 +31,8 @@ SOFTWARE.
 
 #pragma once
 
+#include <tuple>
+
 namespace etsi_its_cpm_ts_msgs::access {
 
 #include <etsi_its_msgs_utils/impl/cdd/cdd_v2-1-1_getters.h>
@@ -257,6 +259,15 @@ inline gm::Point getPositionOfPerceivedObject(const PerceivedObject &object) {
     point.z = double(getCartesianCoordinate(object.position.z_coordinate)) / 100.0;
   }
   return point;
+}
+
+inline std::tuple<double, double, double> getPositionOfPerceivedObjectConfidence(const PerceivedObject &object) {
+  double x_confidence = double(getCartesianCoordinateConfidence(object.position.x_coordinate)) / 100.0;
+  double y_confidence = double(getCartesianCoordinateConfidence(object.position.y_coordinate)) / 100.0;
+  double z_confidence = object.position.z_coordinate_is_present
+                            ? double(getCartesianCoordinateConfidence(object.position.z_coordinate)) / 100.0
+                            : CoordinateConfidence::UNAVAILABLE;
+  return std::make_tuple(x_confidence, y_confidence, z_confidence);
 }
 
 /**

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
@@ -318,6 +318,7 @@ inline gm::Quaternion getOrientationOfPerceivedObject(const PerceivedObject &obj
   }
   yaw = (((double(getCartesianAngle(object.angles.z_angle)) / 10.0)) / 180.0) *
         M_PI;
+  // This wraps from -pi ti pi because setRPY only uses cos and sin of the angles
   q.setRPY(roll, pitch, yaw);
 
   return tf2::toMsg(q);
@@ -368,7 +369,7 @@ inline gm::Pose getPoseOfPerceivedObject(const PerceivedObject &object) {
  * @brief Get the yaw rate of the PerceivedObject
  * 
  * @param object PerceivedObject to get the yaw rate from
- * @return int16_t yaw rate of the PerceivedObject in rad/s
+ * @return double yaw rate of the PerceivedObject in rad/s
  * @throws std::invalid_argument If the yaw rate is not present in the object.
  */
 inline double getYawRateOfPerceivedObject(const PerceivedObject &object) {

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
@@ -261,6 +261,13 @@ inline gm::Point getPositionOfPerceivedObject(const PerceivedObject &object) {
   return point;
 }
 
+/**
+ * @brief Get the Position Confidences Of Perceived Object
+ * 
+ * @param object The PerceivedObject to get the position confidences from
+ * @return std::tuple<double, double, double> x,y and z standard deviations of the positions in meters. 
+ *         The z standard deviation is infinity if the z coordinate is not present.
+ */
 inline std::tuple<double, double, double> getPositionConfidenceOfPerceivedObject(const PerceivedObject &object) {
   double x_confidence = double(getCartesianCoordinateConfidence(object.position.x_coordinate)) / 100.0 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
   double y_confidence = double(getCartesianCoordinateConfidence(object.position.y_coordinate)) / 100.0 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
@@ -302,15 +309,15 @@ inline gm::Quaternion getOrientationOfPerceivedObject(const PerceivedObject &obj
   double roll{0}, pitch{0}, yaw{0};
 
   if (object.angles.x_angle_is_present) {
-    roll = (((double(getCartesianAngle(object.angles.x_angle)) / 10.0) - 180.0) / 180.0) *
-           M_PI;  // TODO: check if 0-360 -> -180-180 is correct
+    roll = (((double(getCartesianAngle(object.angles.x_angle)) / 10.0) ) / 180.0) *
+           M_PI;
   }
   if (object.angles.y_angle_is_present) {
-    pitch = (((double(getCartesianAngle(object.angles.y_angle)) / 10.0) - 180.0) / 180.0) *
-            M_PI;  // TODO: check if 0-360 -> -180-180 is correct
+    pitch = (((double(getCartesianAngle(object.angles.y_angle)) / 10.0) ) / 180.0) *
+            M_PI;
   }
-  yaw = (((double(getCartesianAngle(object.angles.z_angle)) / 10.0) - 180.0) / 180.0) *
-        M_PI;  // TODO: check if 0-360 -> -180-180 is correct
+  yaw = (((double(getCartesianAngle(object.angles.z_angle)) / 10.0)) / 180.0) *
+        M_PI;
   q.setRPY(roll, pitch, yaw);
 
   return tf2::toMsg(q);
@@ -330,6 +337,13 @@ inline double getYawOfPerceivedObject(const PerceivedObject &object) {
   return yaw;
 }
 
+/**
+ * @brief Get the Yaw Confidence Of Perceived Object object
+ * 
+ * @param object PerceivedObject to get the yaw confidence from
+ * @return double The standard deviation of the yaw angle in radians
+ * @throws std::invalid_argument If the angles are not present in the object.
+ */
 inline double getYawConfidenceOfPerceivedObject(const PerceivedObject &object) {
   if(!object.angles_is_present) throw std::invalid_argument("No angles present in PerceivedObject");
   double yaw_confidence = object.angles.z_angle.confidence.value / 10.0 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
@@ -362,6 +376,15 @@ inline double getYawRateOfPerceivedObject(const PerceivedObject &object) {
   return object.z_angular_velocity.value.value * M_PI / 180.0;  // convert to rad/s
 }
 
+/**
+ * @brief Get the Yaw Rate Confidence Of Perceived Object
+ * 
+ * @param object The PerceivedObject to get the yaw rate confidence from
+ * @return double The standard deviation of the yaw rate in rad/s
+ *                As defined in the TS, this is rounded up to the next possible value
+ * @throws std::invalid_argument If the yaw rate is not present in the object.
+ * 
+ */
 inline double getYawRateConfidenceOfPerceivedObject(const PerceivedObject &object) {
   if (!object.z_angular_velocity_is_present) throw std::invalid_argument("No yaw rate present in PerceivedObject");
   auto val = object.z_angular_velocity.confidence.value;
@@ -375,7 +398,7 @@ inline double getYawRateConfidenceOfPerceivedObject(const PerceivedObject &objec
       {AngularSpeedConfidence::DEG_SEC_50, 50.0},
       {AngularSpeedConfidence::OUT_OF_RANGE, std::numeric_limits<double>::infinity()},
   };
-  double confidence = confidence_map.at(val) * M_PI / 180.0 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;  // convert to rad/s
+  return confidence_map.at(val) * M_PI / 180.0 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;  // convert to rad/s
 }
 
 /**
@@ -417,6 +440,14 @@ inline gm::Vector3 getCartesianVelocityOfPerceivedObject(const PerceivedObject &
   return velocity;
 }
 
+/**
+ * @brief Get the Cartesian Velocity Confidence Of Perceived Object object
+ * 
+ * @param object PerceivedObject to get the Cartesian velocity from
+ * @return std::tuple<double, double, double> the x,y and z standard deviations of the velocity in m/s
+ *         The z standard deviation is infinity if the z velocity is not present.
+ * @throws std::invalid_argument If the velocity is no cartesian velocity.
+ */
 inline std::tuple<double, double, double> getCartesianVelocityConfidenceOfPerceivedObject(const PerceivedObject &object) {
   if (!object.velocity_is_present) throw std::invalid_argument("No velocity present in PerceivedObject");
   if (object.velocity.choice != Velocity3dWithConfidence::CHOICE_CARTESIAN_VELOCITY) {
@@ -471,6 +502,14 @@ inline gm::Vector3 getCartesianAccelerationOfPerceivedObject(const PerceivedObje
   return acceleration;
 }
 
+/**
+ * @brief Get the Cartesian Acceleration Confidence Of Perceived Object 
+ * 
+ * @param object PerceivedObject to get the Cartesian acceleration from
+ * @return std::tuple<double, double, double> the x,y and z standard deviations of the acceleration in m/s^2
+ *        The z standard deviation is infinity if the z acceleration is not present.
+ * @throws std::invalid_argument If the acceleration is no cartesian acceleration.
+ */
 inline std::tuple<double, double, double> getCartesianAccelerationConfidenceOfPerceivedObject(const PerceivedObject &object) {
   if (!object.acceleration_is_present) throw std::invalid_argument("No acceleration present in PerceivedObject");
   if (object.acceleration.choice != Acceleration3dWithConfidence::CHOICE_CARTESIAN_ACCELERATION) {
@@ -500,6 +539,13 @@ inline uint16_t getXDimensionOfPerceivedObject(const PerceivedObject &object) {
   return object.object_dimension_x.value.value;
 }
 
+/**
+ * @brief Gets the confidence of the x-dimension of a perceived object.
+ * 
+ * @param object  The PerceivedObject from which to retrieve the x-dimension confidence.
+ * @return uint8_t The confidence of the x-dimension of the perceived object in decimeters.
+ * @throws std::invalid_argument if the x-dimension is not present in the PerceivedObject.
+ */
 inline uint8_t getXDimensionConfidenceOfPerceivedObject(const PerceivedObject &object) {
   if (!object.object_dimension_x_is_present) throw std::invalid_argument("No x-dimension present in PerceivedObject");
   return object.object_dimension_x.confidence.value;
@@ -521,6 +567,13 @@ inline uint16_t getYDimensionOfPerceivedObject(const PerceivedObject &object) {
   return object.object_dimension_y.value.value;
 }
 
+/**
+ * @brief Gets the confidence of the y-dimension of a perceived object.
+ * 
+ * @param object  The PerceivedObject from which to retrieve the y-dimension confidence.
+ * @return uint8_t The confidence of the y-dimension of the perceived object in decimeters.
+ * @throws std::invalid_argument if the y-dimension is not present in the PerceivedObject.
+ */
 inline uint8_t getYDimensionConfidenceOfPerceivedObject(const PerceivedObject &object) {
   if (!object.object_dimension_y_is_present) throw std::invalid_argument("No y-dimension present in PerceivedObject");
   return object.object_dimension_y.confidence.value;
@@ -542,6 +595,13 @@ inline uint16_t getZDimensionOfPerceivedObject(const PerceivedObject &object) {
   return object.object_dimension_z.value.value;
 }
 
+/**
+ * @brief Gets the confidence of the z-dimension of a perceived object.
+ * 
+ * @param object  The PerceivedObject from which to retrieve the z-dimension confidence.
+ * @return uint8_t The confidence of the z-dimension of the perceived object in decimeters.
+ * @throws std::invalid_argument if the z-dimension is not present in the PerceivedObject.
+ */
 inline uint8_t getZDimensionConfidenceOfPerceivedObject(const PerceivedObject &object) {
   if (!object.object_dimension_z_is_present) throw std::invalid_argument("No z-dimension present in PerceivedObject");
   return object.object_dimension_z.confidence.value;
@@ -564,6 +624,12 @@ inline gm::Vector3 getDimensionsOfPerceivedObject(const PerceivedObject &object)
   return dimensions;
 }
 
+/**
+ * @brief Get the Dimensions Confidence Of Perceived Object 
+ * 
+ * @param object The PerceivedObject to get the dimensions confidence from
+ * @return std::tuple<double, double, double> the x,y and z standard deviations of the dimensions in meters
+ */
 inline std::tuple<double, double, double> getDimensionsConfidenceOfPerceivedObject(const PerceivedObject &object) {
   double conf_x = double(getXDimensionConfidenceOfPerceivedObject(object)) / 10.0 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
   double conf_y = double(getYDimensionConfidenceOfPerceivedObject(object)) / 10.0 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
@@ -500,6 +500,11 @@ inline uint16_t getXDimensionOfPerceivedObject(const PerceivedObject &object) {
   return object.object_dimension_x.value.value;
 }
 
+inline uint8_t getXDimensionConfidenceOfPerceivedObject(const PerceivedObject &object) {
+  if (!object.object_dimension_x_is_present) throw std::invalid_argument("No x-dimension present in PerceivedObject");
+  return object.object_dimension_x.confidence.value;
+}
+
 /**
  * @brief Retrieves the y-dimension of a perceived object.
  *
@@ -514,6 +519,11 @@ inline uint16_t getXDimensionOfPerceivedObject(const PerceivedObject &object) {
 inline uint16_t getYDimensionOfPerceivedObject(const PerceivedObject &object) {
   if (!object.object_dimension_y_is_present) throw std::invalid_argument("No y-dimension present in PerceivedObject");
   return object.object_dimension_y.value.value;
+}
+
+inline uint8_t getYDimensionConfidenceOfPerceivedObject(const PerceivedObject &object) {
+  if (!object.object_dimension_y_is_present) throw std::invalid_argument("No y-dimension present in PerceivedObject");
+  return object.object_dimension_y.confidence.value;
 }
 
 /**
@@ -532,6 +542,11 @@ inline uint16_t getZDimensionOfPerceivedObject(const PerceivedObject &object) {
   return object.object_dimension_z.value.value;
 }
 
+inline uint8_t getZDimensionConfidenceOfPerceivedObject(const PerceivedObject &object) {
+  if (!object.object_dimension_z_is_present) throw std::invalid_argument("No z-dimension present in PerceivedObject");
+  return object.object_dimension_z.confidence.value;
+}
+
 /**
  * @brief Retrieves the dimensions of a perceived object.
  *
@@ -547,6 +562,13 @@ inline gm::Vector3 getDimensionsOfPerceivedObject(const PerceivedObject &object)
   dimensions.y = double(getYDimensionOfPerceivedObject(object)) / 10.0;
   dimensions.z = double(getZDimensionOfPerceivedObject(object)) / 10.0;
   return dimensions;
+}
+
+inline std::tuple<double, double, double> getDimensionsConfidenceOfPerceivedObject(const PerceivedObject &object) {
+  double conf_x = double(getXDimensionConfidenceOfPerceivedObject(object)) / 10.0 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
+  double conf_y = double(getYDimensionConfidenceOfPerceivedObject(object)) / 10.0 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
+  double conf_z = double(getZDimensionConfidenceOfPerceivedObject(object)) / 10.0 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
+  return {conf_x, conf_y, conf_z};
 }
 
 /**

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
@@ -148,7 +148,7 @@ inline void setMeasurementDeltaTimeOfPerceivedObject(PerceivedObject& object, co
  * 
  * @param coordinate The CartesianCoordinateWithConfidence object to be modified.
  * @param value The value to be set in centimeters.
- * @param confidence The confidence to be set in centimeters (default: CoordinateConfidence::UNAVAILABLE).
+ * @param confidence The confidence to be set in centimeters (default: infinity, which will map to CoordinateConfidence::UNAVAILABLE).
  */
 inline void setCartesianCoordinateWithConfidence(CartesianCoordinateWithConfidence& coordinate, const double value,
                                                  const double confidence = std::numeric_limits<double>::infinity()) {
@@ -178,18 +178,18 @@ inline void setCartesianCoordinateWithConfidence(CartesianCoordinateWithConfiden
  *
  * @param object The PerceivedObject to set the position for.
  * @param point The gm::Point representing the coordinates of the object in meters.
- * @param x_confidence The confidence value in meters for the x-coordinate (default: CoordinateConfidence::UNAVAILABLE).
- * @param y_confidence The confidence value in meters for the y-coordinate (default: CoordinateConfidence::UNAVAILABLE).
- * @param z_confidence The confidence value in meters for the z-coordinate (default: CoordinateConfidence::UNAVAILABLE).
+ * @param x_std The standard deviation in meters for the x-coordinate (default: infinity).
+ * @param y_std The standard deviation in meters for the y-coordinate (default: infinity).
+ * @param z_std The standard deviation in meters for the z-coordinate (default: infinity).
  */
 inline void setPositionOfPerceivedObject(PerceivedObject& object, const gm::Point& point,
-                                         const double x_confidence = std::numeric_limits<double>::infinity(),
-                                         const double y_confidence = std::numeric_limits<double>::infinity(),
-                                         const double z_confidence = std::numeric_limits<double>::infinity()) {
-  setCartesianCoordinateWithConfidence(object.position.x_coordinate, point.x * 100, x_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
-  setCartesianCoordinateWithConfidence(object.position.y_coordinate, point.y * 100, y_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+                                         const double x_std = std::numeric_limits<double>::infinity(),
+                                         const double y_std = std::numeric_limits<double>::infinity(),
+                                         const double z_std = std::numeric_limits<double>::infinity()) {
+  setCartesianCoordinateWithConfidence(object.position.x_coordinate, point.x * 100, x_std * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+  setCartesianCoordinateWithConfidence(object.position.y_coordinate, point.y * 100, y_std * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   if (point.z != 0.0) {
-    setCartesianCoordinateWithConfidence(object.position.z_coordinate, point.z * 100, z_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+    setCartesianCoordinateWithConfidence(object.position.z_coordinate, point.z * 100, z_std * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
     object.position.z_coordinate_is_present = true;
   }
 }
@@ -203,17 +203,17 @@ inline void setPositionOfPerceivedObject(PerceivedObject& object, const gm::Poin
  * @param cpm The CPM to get the reference position from.
  * @param object The PerceivedObject to set the position for.
  * @param utm_position gm::PointStamped representing the UTM position of the object including the frame_id (utm_<zone><N/S>).
- * @param x_confidence The confidence value in meters for the x coordinate (default: CoordinateConfidence::UNAVAILABLE).
- * @param y_confidence The confidence value in meters for the y coordinate (default: CoordinateConfidence::UNAVAILABLE).
- * @param z_confidence The confidence value in meters for the z coordinate (default: CoordinateConfidence::UNAVAILABLE).
+ * @param x_confidence The standard deviation in meters for the x coordinate (default: CoordinateConfidence::UNAVAILABLE).
+ * @param y_confidence The standard deviation in meters for the y coordinate (default: CoordinateConfidence::UNAVAILABLE).
+ * @param z_confidence The standard deviation in meters for the z coordinate (default: CoordinateConfidence::UNAVAILABLE).
  *
  * @throws std::invalid_argument if the UTM-Position frame_id does not match the reference position frame_id.
  */
 inline void setUTMPositionOfPerceivedObject(CollectivePerceptionMessage& cpm, PerceivedObject& object,
                                             const gm::PointStamped& utm_position,
-                                            const double x_confidence = std::numeric_limits<double>::infinity(),
-                                            const double y_confidence = std::numeric_limits<double>::infinity(),
-                                            const double z_confidence = std::numeric_limits<double>::infinity()) {
+                                            const double x_std = std::numeric_limits<double>::infinity(),
+                                            const double y_std = std::numeric_limits<double>::infinity(),
+                                            const double z_std = std::numeric_limits<double>::infinity()) {
   gm::PointStamped reference_position = getUTMPosition(cpm);
   if (utm_position.header.frame_id != reference_position.header.frame_id) {
     throw std::invalid_argument("UTM-Position frame_id (" + utm_position.header.frame_id +
@@ -221,12 +221,12 @@ inline void setUTMPositionOfPerceivedObject(CollectivePerceptionMessage& cpm, Pe
                                 ")");
   }
   setCartesianCoordinateWithConfidence(object.position.x_coordinate,
-                                       (utm_position.point.x - reference_position.point.x) * 100, x_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+                                       (utm_position.point.x - reference_position.point.x) * 100, x_std * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   setCartesianCoordinateWithConfidence(object.position.y_coordinate,
-                                       (utm_position.point.y - reference_position.point.y) * 100, y_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+                                       (utm_position.point.y - reference_position.point.y) * 100, y_std * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   if (utm_position.point.z != 0.0) {
     setCartesianCoordinateWithConfidence(object.position.z_coordinate,
-                                         (utm_position.point.z - reference_position.point.z) * 100, z_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+                                         (utm_position.point.z - reference_position.point.z) * 100, z_std * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
     object.position.z_coordinate_is_present = true;
   }
 }
@@ -240,7 +240,7 @@ inline void setUTMPositionOfPerceivedObject(CollectivePerceptionMessage& cpm, Pe
  *
  * @param velocity The VelocityComponent object to set the value and confidence for.
  * @param value The value to set for the VelocityComponent in cm/s.
- * @param confidence The confidence to set for the VelocityComponent in cm/s. Default value is SpeedConfidence::UNAVAILABLE.
+ * @param confidence The confidence to set for the VelocityComponent in cm/s. Default value is infinity, mapping to SpeedConfidence::UNAVAILABLE.
  */
 inline void setVelocityComponent(VelocityComponent& velocity, const double value,
                                  const double confidence = std::numeric_limits<double>::infinity()) {
@@ -271,19 +271,19 @@ inline void setVelocityComponent(VelocityComponent& velocity, const double value
  *
  * @param object The perceived object for which the velocity is being set.
  * @param cartesian_velocity The Cartesian velocity components (x, y, z) of the object (in m/s).
- * @param x_confidence The confidence value in m/s for the x velocity component (default: SpeedConfidence::UNAVAILABLE).
- * @param y_confidence The confidence value in m/s for the y velocity component (default: SpeedConfidence::UNAVAILABLE).
- * @param z_confidence The confidence value in m/s for the z velocity component (default: SpeedConfidence::UNAVAILABLE).
+ * @param x_std The standard deviation in m/s for the x velocity component (default: infinity).
+ * @param y_std The standard deviation in m/s for the y velocity component (default: infinity).
+ * @param z_std The standard deviation in m/s for the z velocity component (default: infinity).
  */
 inline void setVelocityOfPerceivedObject(PerceivedObject& object, const gm::Vector3& cartesian_velocity,
-                                         const double x_confidence = SpeedConfidence::UNAVAILABLE,
-                                         const double y_confidence = SpeedConfidence::UNAVAILABLE,
-                                         const double z_confidence = SpeedConfidence::UNAVAILABLE) {
+                                         const double x_std = std::numeric_limits<double>::infinity(),
+                                         const double y_std = std::numeric_limits<double>::infinity(),
+                                         const double z_std = std::numeric_limits<double>::infinity()) {
   object.velocity.choice = Velocity3dWithConfidence::CHOICE_CARTESIAN_VELOCITY;
-  setVelocityComponent(object.velocity.cartesian_velocity.x_velocity, cartesian_velocity.x * 100, x_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
-  setVelocityComponent(object.velocity.cartesian_velocity.y_velocity, cartesian_velocity.y * 100, y_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+  setVelocityComponent(object.velocity.cartesian_velocity.x_velocity, cartesian_velocity.x * 100, x_std * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+  setVelocityComponent(object.velocity.cartesian_velocity.y_velocity, cartesian_velocity.y * 100, y_std * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   if (cartesian_velocity.z != 0.0) {
-    setVelocityComponent(object.velocity.cartesian_velocity.z_velocity, cartesian_velocity.z * 100, z_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+    setVelocityComponent(object.velocity.cartesian_velocity.z_velocity, cartesian_velocity.z * 100, z_std * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
     object.velocity.cartesian_velocity.z_velocity_is_present = true;
   }
   object.velocity_is_present = true;
@@ -298,7 +298,7 @@ inline void setVelocityOfPerceivedObject(PerceivedObject& object, const gm::Vect
  *
  * @param acceleration The AccelerationComponent object to set the value and confidence for.
  * @param value The value to set for the AccelerationComponent in dm/s^2.
- * @param confidence The confidence to set for the AccelerationComponent in dm/s^2. Default value is AccelerationConfidence::UNAVAILABLE.
+ * @param confidence The confidence to set for the AccelerationComponent in dm/s^2. Default value is infinity, mapping to AccelerationConfidence::UNAVAILABLE.
  */
 inline void setAccelerationComponent(AccelerationComponent& acceleration, const double value,
                                      const double confidence = std::numeric_limits<double>::infinity()) {
@@ -329,22 +329,22 @@ inline void setAccelerationComponent(AccelerationComponent& acceleration, const 
  *
  * @param object The perceived object for which the acceleration is being set.
  * @param cartesian_acceleration The Cartesian acceleration components (x, y, z) of the object (in m/s^2).
- * @param x_confidence The confidence value in m/s^2 for the x acceleration component (default: AccelerationConfidence::UNAVAILABLE).
- * @param y_confidence The confidence value in m/s^2 for the y acceleration component (default: AccelerationConfidence::UNAVAILABLE).
- * @param z_confidence The confidence value in m/s^2 for the z acceleration component (default: AccelerationConfidence::UNAVAILABLE).
+ * @param x_std The standard deviation in m/s^2 for the x acceleration component (default: infinity).
+ * @param y_std The standard deviation in m/s^2 for the y acceleration component (default: infinity).
+ * @param z_std The standard deviation in m/s^2 for the z acceleration component (default: infinity).
  */
 inline void setAccelerationOfPerceivedObject(PerceivedObject& object, const gm::Vector3& cartesian_acceleration,
-                                             const double x_confidence = std::numeric_limits<double>::infinity(),
-                                             const double y_confidence = std::numeric_limits<double>::infinity(),
-                                             const double z_confidence = std::numeric_limits<double>::infinity()) {
+                                             const double x_std = std::numeric_limits<double>::infinity(),
+                                             const double y_std = std::numeric_limits<double>::infinity(),
+                                             const double z_std = std::numeric_limits<double>::infinity()) {
   object.acceleration.choice = Acceleration3dWithConfidence::CHOICE_CARTESIAN_ACCELERATION;
   setAccelerationComponent(object.acceleration.cartesian_acceleration.x_acceleration, cartesian_acceleration.x * 10,
-                           x_confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+                           x_std * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   setAccelerationComponent(object.acceleration.cartesian_acceleration.y_acceleration, cartesian_acceleration.y * 10,
-                           y_confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+                           y_std * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   if (cartesian_acceleration.z != 0.0) {
     setAccelerationComponent(object.acceleration.cartesian_acceleration.z_acceleration, cartesian_acceleration.z * 10,
-                             z_confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+                             z_std * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
     object.acceleration.cartesian_acceleration.z_acceleration_is_present = true;
   }
   object.acceleration_is_present = true;
@@ -358,26 +358,26 @@ inline void setAccelerationOfPerceivedObject(PerceivedObject& object, const gm::
  *
  * @param object The PerceivedObject to set the yaw angle for.
  * @param yaw The yaw angle in radians.
- * @param confidence The standard deviation of the yaw angle in radians (optional, default is Infinity).
+ * @param yaw_std The standard deviation of the yaw angle in radians (optional, default is Infinity).
  */
 inline void setYawOfPerceivedObject(PerceivedObject& object, const double yaw,
-                                    double confidence = std::numeric_limits<double>::infinity()) {
+                                    double yaw_std = std::numeric_limits<double>::infinity()) {
   // wrap angle to range [0, 360]
-  double yaw_in_degrees = yaw * 180 / M_PI + 180;  // TODO: check if this is correct
+  double yaw_in_degrees = yaw * 180 / M_PI;
   while (yaw_in_degrees > 360.0) yaw_in_degrees -= 360.0;
-  while (yaw_in_degrees < 0) yaw_in_degrees += 360.0;
+  while (yaw_in_degrees <= 0.0) yaw_in_degrees += 360.0;
   object.angles.z_angle.value.value = yaw_in_degrees * 10;
 
-  if(confidence == std::numeric_limits<double>::infinity()) {
-    confidence = AngleConfidence::UNAVAILABLE;
+  if(yaw_std == std::numeric_limits<double>::infinity()) {
+    object.angles.z_angle.confidence.value = AngleConfidence::UNAVAILABLE;
   } else {
-    confidence *= 180.0 / M_PI;
-    confidence *= 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;  // convert to 0.1 degrees
+    yaw_std *= 180.0 / M_PI;
+    yaw_std *= 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;  // convert to 0.1 degrees
 
-    if (confidence > AngleConfidence::MAX || confidence < AngleConfidence::MIN) {
+    if (yaw_std > AngleConfidence::MAX || yaw_std < AngleConfidence::MIN) {
       object.angles.z_angle.confidence.value = AngleConfidence::OUT_OF_RANGE;
     } else {
-      object.angles.z_angle.confidence.value = static_cast<uint8_t>(confidence);
+      object.angles.z_angle.confidence.value = static_cast<uint8_t>(yaw_std);
     }
   }
   object.angles_is_present = true;
@@ -392,10 +392,10 @@ inline void setYawOfPerceivedObject(PerceivedObject& object, const double yaw,
  *
  * @param object The PerceivedObject to set the yaw rate for.
  * @param yaw_rate The yaw rate in rad/s.
- * @param confidence Confidence of the yaw rate defined in AngularSpeedConfidence (optional, default is AngularSpeedConfidence::UNAVAILABLE).
+ * @param yaw_rate_std Standard deviation of the yaw rate in rad/s (optional, default is infinity, mapping to AngularSpeedConfidence::UNAVAILABLE).
  */
 inline void setYawRateOfPerceivedObject(PerceivedObject& object, const double yaw_rate,
-                                        double confidence = std::numeric_limits<double>::infinity()) {
+                                        double yaw_rate_std = std::numeric_limits<double>::infinity()) {
   double yaw_rate_in_degrees = yaw_rate * 180.0 / M_PI;
   // limit value range
   if (yaw_rate_in_degrees < CartesianAngularVelocityComponentValue::NEGATIVE_OUTOF_RANGE) {
@@ -406,11 +406,11 @@ inline void setYawRateOfPerceivedObject(PerceivedObject& object, const double ya
   
   object.z_angular_velocity.value.value = yaw_rate_in_degrees;
 
-  if(confidence == std::numeric_limits<double>::infinity()) {
+  if(yaw_rate_std == std::numeric_limits<double>::infinity()) {
     object.z_angular_velocity.confidence.value = AngularSpeedConfidence::UNAVAILABLE;
   } else {
-    confidence *= 180.0 / M_PI;
-    confidence *= etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;  // convert to degrees/s
+    yaw_rate_std *= 180.0 / M_PI;
+    yaw_rate_std *= etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;  // convert to degrees/s
     // How stupid is this?!
     static const std::map<double, uint8_t> confidence_map = {
         {1.0, AngularSpeedConfidence::DEG_SEC_01},
@@ -422,7 +422,7 @@ inline void setYawRateOfPerceivedObject(PerceivedObject& object, const double ya
         {std::numeric_limits<double>::infinity(), AngularSpeedConfidence::OUT_OF_RANGE},
     };
     for(const auto& [thresh, conf_val] : confidence_map) {
-      if (confidence <= thresh) {
+      if (yaw_rate_std <= thresh) {
         object.z_angular_velocity.confidence.value = conf_val;
         break;
       }
@@ -444,7 +444,7 @@ inline void setYawRateOfPerceivedObject(PerceivedObject& object, const double ya
  * 
  * @param dimension The object dimension to be set.
  * @param value The value of the object dimension in decimeters.
- * @param confidence The confidence of the object dimension in decimeters (optional, default is ObjectDimensionConfidence::UNAVAILABLE).
+ * @param confidence The confidence of the object dimension in decimeters (optional, default is infinty, mapping to ObjectDimensionConfidence::UNAVAILABLE).
  */
 inline void setObjectDimension(ObjectDimension& dimension, const double value,
                                const double confidence = std::numeric_limits<double>::infinity()) {
@@ -474,11 +474,11 @@ inline void setObjectDimension(ObjectDimension& dimension, const double value,
  *
  * @param object The `PerceivedObject` to modify.
  * @param value The value to set as the x-dimension in meters.
- * @param confidence The confidence of the x-dimension value in meters (optional, default is `ObjectDimensionConfidence::UNAVAILABLE`).
+ * @param std The standard deviation of the x-dimension value in meters (optional, default is infinity).
  */
 inline void setXDimensionOfPerceivedObject(PerceivedObject& object, const double value,
-                                           const double confidence = ObjectDimensionConfidence::UNAVAILABLE) {
-  setObjectDimension(object.object_dimension_x, value * 10, confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+                                           const double std = std::numeric_limits<double>::infinity()) {
+  setObjectDimension(object.object_dimension_x, value * 10, std * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   object.object_dimension_x_is_present = true;
 }
 
@@ -490,11 +490,11 @@ inline void setXDimensionOfPerceivedObject(PerceivedObject& object, const double
  *
  * @param object The `PerceivedObject` to modify.
  * @param value The value to set as the y-dimension in meters.
- * @param confidence The confidence of the y-dimension value in meters (optional, default is `ObjectDimensionConfidence::UNAVAILABLE`).
+ * @param std The standard deviation of the y-dimension value in meters (optional, default is infinity).
  */
 inline void setYDimensionOfPerceivedObject(PerceivedObject& object, const double value,
-                                           const double confidence = ObjectDimensionConfidence::UNAVAILABLE) {
-  setObjectDimension(object.object_dimension_y, value * 10, confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+                                           const double std = std::numeric_limits<double>::infinity()) {
+  setObjectDimension(object.object_dimension_y, value * 10, std * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   object.object_dimension_y_is_present = true;
 }
 
@@ -506,11 +506,11 @@ inline void setYDimensionOfPerceivedObject(PerceivedObject& object, const double
  *
  * @param object The `PerceivedObject` to modify.
  * @param value The value to set as the z-dimension in meters.
- * @param confidence The confidence of the z-dimension value in meters (optional, default is `ObjectDimensionConfidence::UNAVAILABLE`).
+ * @param std The standard deviation of the z-dimension value in meters (optional, default is infinity).
  */
 inline void setZDimensionOfPerceivedObject(PerceivedObject& object, const double value,
-                                           const double confidence = ObjectDimensionConfidence::UNAVAILABLE) {
-  setObjectDimension(object.object_dimension_z, value * 10, confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+                                           const double std = std::numeric_limits<double>::infinity()) {
+  setObjectDimension(object.object_dimension_z, value * 10, std * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   object.object_dimension_z_is_present = true;
 }
 
@@ -521,17 +521,17 @@ inline void setZDimensionOfPerceivedObject(PerceivedObject& object, const double
  *
  * @param object The perceived object to set the dimensions for.
  * @param dimensions The dimensions of the object as a gm::Vector3 (x, y, z) in meters.
- * @param x_confidence The standard deviation in meters for the x dimension (optional, default: ObjectDimensionConfidence::UNAVAILABLE).
- * @param y_confidence The standard deviation in meters for the y dimension (optional, default: ObjectDimensionConfidence::UNAVAILABLE).
- * @param z_confidence The standard deviation in meters for the z dimension (optional, default: ObjectDimensionConfidence::UNAVAILABLE).
+ * @param x_std The standard deviation in meters for the x dimension (optional, default: infinity).
+ * @param y_std The standard deviation in meters for the y dimension (optional, default: infinity).
+ * @param z_std The standard deviation in meters for the z dimension (optional, default: infinity).
  */
 inline void setDimensionsOfPerceivedObject(PerceivedObject& object, const gm::Vector3& dimensions,
-                                           const double x_confidence = std::numeric_limits<double>::infinity(),
-                                           const double y_confidence = std::numeric_limits<double>::infinity(),
-                                           const double z_confidence = std::numeric_limits<double>::infinity()) {
-  setXDimensionOfPerceivedObject(object, dimensions.x, x_confidence);
-  setYDimensionOfPerceivedObject(object, dimensions.y, y_confidence);
-  setZDimensionOfPerceivedObject(object, dimensions.z, z_confidence);
+                                           const double x_std = std::numeric_limits<double>::infinity(),
+                                           const double y_std = std::numeric_limits<double>::infinity(),
+                                           const double z_std = std::numeric_limits<double>::infinity()) {
+  setXDimensionOfPerceivedObject(object, dimensions.x, x_std);
+  setYDimensionOfPerceivedObject(object, dimensions.y, y_std);
+  setZDimensionOfPerceivedObject(object, dimensions.z, z_std);
 }
 
 /**

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
@@ -439,8 +439,8 @@ inline void setObjectDimension(ObjectDimension& dimension, const uint16_t value,
  * @param confidence The confidence of the x-dimension value in meters (optional, default is `ObjectDimensionConfidence::UNAVAILABLE`).
  */
 inline void setXDimensionOfPerceivedObject(PerceivedObject& object, const double value,
-                                           const uint8_t confidence = ObjectDimensionConfidence::UNAVAILABLE) {
-  setObjectDimension(object.object_dimension_x, (uint16_t)(value * 10), confidence * 10);
+                                           const double confidence = ObjectDimensionConfidence::UNAVAILABLE) {
+  setObjectDimension(object.object_dimension_x, static_cast<uint16_t>(value * 10), static_cast<uint8_t>(confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR));
   object.object_dimension_x_is_present = true;
 }
 
@@ -455,8 +455,8 @@ inline void setXDimensionOfPerceivedObject(PerceivedObject& object, const double
  * @param confidence The confidence of the y-dimension value in meters (optional, default is `ObjectDimensionConfidence::UNAVAILABLE`).
  */
 inline void setYDimensionOfPerceivedObject(PerceivedObject& object, const double value,
-                                           const uint8_t confidence = ObjectDimensionConfidence::UNAVAILABLE) {
-  setObjectDimension(object.object_dimension_y, (uint16_t)(value * 10), confidence * 10);
+                                           const double confidence = ObjectDimensionConfidence::UNAVAILABLE) {
+  setObjectDimension(object.object_dimension_y, static_cast<uint16_t>(value * 10), static_cast<uint8_t>(confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR));
   object.object_dimension_y_is_present = true;
 }
 
@@ -471,8 +471,8 @@ inline void setYDimensionOfPerceivedObject(PerceivedObject& object, const double
  * @param confidence The confidence of the z-dimension value in meters (optional, default is `ObjectDimensionConfidence::UNAVAILABLE`).
  */
 inline void setZDimensionOfPerceivedObject(PerceivedObject& object, const double value,
-                                           const uint8_t confidence = ObjectDimensionConfidence::UNAVAILABLE) {
-  setObjectDimension(object.object_dimension_z, (uint16_t)(value * 10), confidence * 10);
+                                           const double confidence = ObjectDimensionConfidence::UNAVAILABLE) {
+  setObjectDimension(object.object_dimension_z, static_cast<uint16_t>(value * 10), static_cast<uint8_t>(confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR));
   object.object_dimension_z_is_present = true;
 }
 
@@ -483,14 +483,14 @@ inline void setZDimensionOfPerceivedObject(PerceivedObject& object, const double
  *
  * @param object The perceived object to set the dimensions for.
  * @param dimensions The dimensions of the object as a gm::Vector3 (x, y, z) in meters.
- * @param x_confidence The confidence in meters for the x dimension (optional, default: ObjectDimensionConfidence::UNAVAILABLE).
- * @param y_confidence The confidence in meters for the y dimension (optional, default: ObjectDimensionConfidence::UNAVAILABLE).
- * @param z_confidence The confidence in meters for the z dimension (optional, default: ObjectDimensionConfidence::UNAVAILABLE).
+ * @param x_confidence The standard deviation in meters for the x dimension (optional, default: ObjectDimensionConfidence::UNAVAILABLE).
+ * @param y_confidence The standard deviation in meters for the y dimension (optional, default: ObjectDimensionConfidence::UNAVAILABLE).
+ * @param z_confidence The standard deviation in meters for the z dimension (optional, default: ObjectDimensionConfidence::UNAVAILABLE).
  */
 inline void setDimensionsOfPerceivedObject(PerceivedObject& object, const gm::Vector3& dimensions,
-                                           const uint8_t x_confidence = ObjectDimensionConfidence::UNAVAILABLE,
-                                           const uint8_t y_confidence = ObjectDimensionConfidence::UNAVAILABLE,
-                                           const uint8_t z_confidence = ObjectDimensionConfidence::UNAVAILABLE) {
+                                           const double x_confidence = ObjectDimensionConfidence::UNAVAILABLE,
+                                           const double y_confidence = ObjectDimensionConfidence::UNAVAILABLE,
+                                           const double z_confidence = ObjectDimensionConfidence::UNAVAILABLE) {
   setXDimensionOfPerceivedObject(object, dimensions.x, x_confidence);
   setYDimensionOfPerceivedObject(object, dimensions.y, y_confidence);
   setZDimensionOfPerceivedObject(object, dimensions.z, z_confidence);
@@ -584,6 +584,19 @@ inline void addContainerToCPM(CollectivePerceptionMessage& cpm, const WrappedCpm
   } else {
     throw std::invalid_argument("Maximum number of CPM-Containers reached");
   }
+}
+
+/**
+ * @brief Set the confidence of the reference position
+ * 
+ * @param cpm CPM-Message to set the confidence
+ * @param covariance_matrix The four values of the covariance matrix in the order: cov_xx, cov_xy, cov_yx, cov_yy
+ *                          The matrix has to be SPD, otherwise a std::invalid_argument exception is thrown.
+ *                          Its coordinate system is WGS84 (x = North, y = East)
+ */
+inline void setWGSRefPosConfidence(CollectivePerceptionMessage& cpm, const std::array<double, 4>& covariance_matrix) {
+  setWGSPosConfidenceEllipse(cpm.payload.management_container.reference_position.position_confidence_ellipse,
+                             covariance_matrix);
 }
 
 }  // namespace etsi_its_cpm_ts_msgs::access

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
@@ -181,13 +181,13 @@ inline void setCartesianCoordinateWithConfidence(CartesianCoordinateWithConfiden
  * @param z_confidence The confidence value in meters for the z-coordinate (default: CoordinateConfidence::UNAVAILABLE).
  */
 inline void setPositionOfPerceivedObject(PerceivedObject& object, const gm::Point& point,
-                                         const uint16_t x_confidence = CoordinateConfidence::UNAVAILABLE,
-                                         const uint16_t y_confidence = CoordinateConfidence::UNAVAILABLE,
-                                         const uint16_t z_confidence = CoordinateConfidence::UNAVAILABLE) {
-  setCartesianCoordinateWithConfidence(object.position.x_coordinate, point.x * 100, x_confidence * 100);
-  setCartesianCoordinateWithConfidence(object.position.y_coordinate, point.y * 100, y_confidence * 100);
+                                         const double x_confidence = CoordinateConfidence::UNAVAILABLE,
+                                         const double y_confidence = CoordinateConfidence::UNAVAILABLE,
+                                         const double z_confidence = CoordinateConfidence::UNAVAILABLE) {
+  setCartesianCoordinateWithConfidence(object.position.x_coordinate, point.x * 100, x_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+  setCartesianCoordinateWithConfidence(object.position.y_coordinate, point.y * 100, y_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   if (point.z != 0.0) {
-    setCartesianCoordinateWithConfidence(object.position.z_coordinate, point.z * 100, z_confidence * 100);
+    setCartesianCoordinateWithConfidence(object.position.z_coordinate, point.z * 100, z_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
     object.position.z_coordinate_is_present = true;
   }
 }
@@ -219,12 +219,12 @@ inline void setUTMPositionOfPerceivedObject(CollectivePerceptionMessage& cpm, Pe
                                 ")");
   }
   setCartesianCoordinateWithConfidence(object.position.x_coordinate,
-                                       (utm_position.point.x - reference_position.point.x) * 100, x_confidence * 100);
+                                       (utm_position.point.x - reference_position.point.x) * 100, x_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   setCartesianCoordinateWithConfidence(object.position.y_coordinate,
-                                       (utm_position.point.y - reference_position.point.y) * 100, y_confidence * 100);
+                                       (utm_position.point.y - reference_position.point.y) * 100, y_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   if (utm_position.point.z != 0.0) {
     setCartesianCoordinateWithConfidence(object.position.z_coordinate,
-                                         (utm_position.point.z - reference_position.point.z) * 100, z_confidence * 100);
+                                         (utm_position.point.z - reference_position.point.z) * 100, z_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
     object.position.z_coordinate_is_present = true;
   }
 }
@@ -240,22 +240,24 @@ inline void setUTMPositionOfPerceivedObject(CollectivePerceptionMessage& cpm, Pe
  * @param value The value to set for the VelocityComponent in cm/s.
  * @param confidence The confidence to set for the VelocityComponent in cm/s. Default value is SpeedConfidence::UNAVAILABLE.
  */
-inline void setVelocityComponent(VelocityComponent& velocity, const int16_t value,
-                                 const uint8_t confidence = SpeedConfidence::UNAVAILABLE) {
+inline void setVelocityComponent(VelocityComponent& velocity, const double value,
+                                 const double confidence = std::numeric_limits<double>::infinity()) {
   // limit value range
   if (value < VelocityComponentValue::NEGATIVE_OUT_OF_RANGE) {
     velocity.value.value = VelocityComponentValue::NEGATIVE_OUT_OF_RANGE;
   } else if (value > VelocityComponentValue::POSITIVE_OUT_OF_RANGE) {
     velocity.value.value = VelocityComponentValue::POSITIVE_OUT_OF_RANGE;
   } else {
-    velocity.value.value = value;
+    velocity.value.value = static_cast<int16_t>(value);
   }
 
   // limit confidence range
-  if (confidence > SpeedConfidence::MAX || confidence < SpeedConfidence::MIN) {
+  if(confidence == std::numeric_limits<double>::infinity()) {
+    velocity.confidence.value = SpeedConfidence::UNAVAILABLE;
+  } else if (confidence > SpeedConfidence::MAX || confidence < SpeedConfidence::MIN) {
     velocity.confidence.value = SpeedConfidence::OUT_OF_RANGE;
   } else {
-    velocity.confidence.value = confidence;
+    velocity.confidence.value = static_cast<uint8_t>(confidence);
   }
 }
 
@@ -272,14 +274,14 @@ inline void setVelocityComponent(VelocityComponent& velocity, const int16_t valu
  * @param z_confidence The confidence value in m/s for the z velocity component (default: SpeedConfidence::UNAVAILABLE).
  */
 inline void setVelocityOfPerceivedObject(PerceivedObject& object, const gm::Vector3& cartesian_velocity,
-                                         const uint8_t x_confidence = SpeedConfidence::UNAVAILABLE,
-                                         const uint8_t y_confidence = SpeedConfidence::UNAVAILABLE,
-                                         const uint8_t z_confidence = SpeedConfidence::UNAVAILABLE) {
+                                         const double x_confidence = SpeedConfidence::UNAVAILABLE,
+                                         const double y_confidence = SpeedConfidence::UNAVAILABLE,
+                                         const double z_confidence = SpeedConfidence::UNAVAILABLE) {
   object.velocity.choice = Velocity3dWithConfidence::CHOICE_CARTESIAN_VELOCITY;
-  setVelocityComponent(object.velocity.cartesian_velocity.x_velocity, cartesian_velocity.x * 100, x_confidence * 100);
-  setVelocityComponent(object.velocity.cartesian_velocity.y_velocity, cartesian_velocity.y * 100, y_confidence * 100);
+  setVelocityComponent(object.velocity.cartesian_velocity.x_velocity, cartesian_velocity.x * 100, x_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+  setVelocityComponent(object.velocity.cartesian_velocity.y_velocity, cartesian_velocity.y * 100, y_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   if (cartesian_velocity.z != 0.0) {
-    setVelocityComponent(object.velocity.cartesian_velocity.z_velocity, cartesian_velocity.z * 100, z_confidence * 100);
+    setVelocityComponent(object.velocity.cartesian_velocity.z_velocity, cartesian_velocity.z * 100, z_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
     object.velocity.cartesian_velocity.z_velocity_is_present = true;
   }
   object.velocity_is_present = true;
@@ -296,22 +298,24 @@ inline void setVelocityOfPerceivedObject(PerceivedObject& object, const gm::Vect
  * @param value The value to set for the AccelerationComponent in dm/s^2.
  * @param confidence The confidence to set for the AccelerationComponent in dm/s^2. Default value is AccelerationConfidence::UNAVAILABLE.
  */
-inline void setAccelerationComponent(AccelerationComponent& acceleration, const int16_t value,
-                                     const uint8_t confidence = AccelerationConfidence::UNAVAILABLE) {
+inline void setAccelerationComponent(AccelerationComponent& acceleration, const double value,
+                                     const double confidence = std::numeric_limits<double>::infinity()) {
   // limit value range
   if (value < AccelerationValue::NEGATIVE_OUT_OF_RANGE) {
     acceleration.value.value = AccelerationValue::NEGATIVE_OUT_OF_RANGE;
   } else if (value > AccelerationValue::POSITIVE_OUT_OF_RANGE) {
     acceleration.value.value = AccelerationValue::POSITIVE_OUT_OF_RANGE;
   } else {
-    acceleration.value.value = value;
+    acceleration.value.value = static_cast<int16_t>(value);
   }
 
   // limit confidence range
-  if (confidence > AccelerationConfidence::MAX || confidence < AccelerationConfidence::MIN) {
+  if(confidence == std::numeric_limits<double>::infinity()) {
+    acceleration.confidence.value = AccelerationConfidence::UNAVAILABLE;
+  } else if (confidence > AccelerationConfidence::MAX || confidence < AccelerationConfidence::MIN) {
     acceleration.confidence.value = AccelerationConfidence::OUT_OF_RANGE;
   } else {
-    acceleration.confidence.value = confidence;
+    acceleration.confidence.value = static_cast<uint8_t>(confidence);
   }
 }
 
@@ -328,17 +332,17 @@ inline void setAccelerationComponent(AccelerationComponent& acceleration, const 
  * @param z_confidence The confidence value in m/s^2 for the z acceleration component (default: AccelerationConfidence::UNAVAILABLE).
  */
 inline void setAccelerationOfPerceivedObject(PerceivedObject& object, const gm::Vector3& cartesian_acceleration,
-                                             const uint8_t x_confidence = AccelerationConfidence::UNAVAILABLE,
-                                             const uint8_t y_confidence = AccelerationConfidence::UNAVAILABLE,
-                                             const uint8_t z_confidence = AccelerationConfidence::UNAVAILABLE) {
+                                             const double x_confidence = std::numeric_limits<double>::infinity(),
+                                             const double y_confidence = std::numeric_limits<double>::infinity(),
+                                             const double z_confidence = std::numeric_limits<double>::infinity()) {
   object.acceleration.choice = Acceleration3dWithConfidence::CHOICE_CARTESIAN_ACCELERATION;
   setAccelerationComponent(object.acceleration.cartesian_acceleration.x_acceleration, cartesian_acceleration.x * 10,
-                           x_confidence * 10);
+                           x_confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   setAccelerationComponent(object.acceleration.cartesian_acceleration.y_acceleration, cartesian_acceleration.y * 10,
-                           y_confidence * 10);
+                           y_confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   if (cartesian_acceleration.z != 0.0) {
     setAccelerationComponent(object.acceleration.cartesian_acceleration.z_acceleration, cartesian_acceleration.z * 10,
-                             z_confidence * 10);
+                             z_confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
     object.acceleration.cartesian_acceleration.z_acceleration_is_present = true;
   }
   object.acceleration_is_present = true;
@@ -352,20 +356,27 @@ inline void setAccelerationOfPerceivedObject(PerceivedObject& object, const gm::
  *
  * @param object The PerceivedObject to set the yaw angle for.
  * @param yaw The yaw angle in radians.
- * @param confidence The confidence level of the yaw angle in 0,1 degrees (optional, default is AngleConfidence::UNAVAILABLE).
+ * @param confidence The standard deviation of the yaw angle in radians (optional, default is Infinity).
  */
 inline void setYawOfPerceivedObject(PerceivedObject& object, const double yaw,
-                                    const uint8_t confidence = AngleConfidence::UNAVAILABLE) {
+                                    double confidence = std::numeric_limits<double>::infinity()) {
   // wrap angle to range [0, 360]
   double yaw_in_degrees = yaw * 180 / M_PI + 180;  // TODO: check if this is correct
   while (yaw_in_degrees > 360.0) yaw_in_degrees -= 360.0;
   while (yaw_in_degrees < 0) yaw_in_degrees += 360.0;
   object.angles.z_angle.value.value = yaw_in_degrees * 10;
 
-  if (confidence > AngleConfidence::MAX || confidence < AngleConfidence::MIN) {
-    object.angles.z_angle.confidence.value = AngleConfidence::OUT_OF_RANGE;
+  if(confidence == std::numeric_limits<double>::infinity()) {
+    confidence = AngleConfidence::UNAVAILABLE;
   } else {
-    object.angles.z_angle.confidence.value = confidence;
+    confidence *= 180.0 / M_PI;
+    confidence *= 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;  // convert to 0.1 degrees
+
+    if (confidence > AngleConfidence::MAX || confidence < AngleConfidence::MIN) {
+      object.angles.z_angle.confidence.value = AngleConfidence::OUT_OF_RANGE;
+    } else {
+      object.angles.z_angle.confidence.value = static_cast<uint8_t>(confidence);
+    }
   }
   object.angles_is_present = true;
 }
@@ -382,18 +393,40 @@ inline void setYawOfPerceivedObject(PerceivedObject& object, const double yaw,
  * @param confidence Confidence of the yaw rate defined in AngularSpeedConfidence (optional, default is AngularSpeedConfidence::UNAVAILABLE).
  */
 inline void setYawRateOfPerceivedObject(PerceivedObject& object, const double yaw_rate,
-                                        const uint8_t confidence = AngularSpeedConfidence::UNAVAILABLE) {
-  int16_t yaw_rate_in_degrees = yaw_rate * 180 / M_PI;
-  if (yaw_rate_in_degrees != CartesianAngularVelocityComponentValue::UNAVAILABLE) {
-    // limit value range
-    if (yaw_rate_in_degrees < CartesianAngularVelocityComponentValue::NEGATIVE_OUTOF_RANGE) {
-      yaw_rate_in_degrees = CartesianAngularVelocityComponentValue::NEGATIVE_OUTOF_RANGE;
-    } else if (yaw_rate_in_degrees > CartesianAngularVelocityComponentValue::POSITIVE_OUT_OF_RANGE) {
-      yaw_rate_in_degrees = CartesianAngularVelocityComponentValue::POSITIVE_OUT_OF_RANGE;
+                                        double confidence = std::numeric_limits<double>::infinity()) {
+  double yaw_rate_in_degrees = yaw_rate * 180.0 / M_PI;
+  // limit value range
+  if (yaw_rate_in_degrees < CartesianAngularVelocityComponentValue::NEGATIVE_OUTOF_RANGE) {
+    yaw_rate_in_degrees = CartesianAngularVelocityComponentValue::NEGATIVE_OUTOF_RANGE;
+  } else if (yaw_rate_in_degrees > CartesianAngularVelocityComponentValue::POSITIVE_OUT_OF_RANGE) {
+    yaw_rate_in_degrees = CartesianAngularVelocityComponentValue::POSITIVE_OUT_OF_RANGE;
+  }
+  
+  object.z_angular_velocity.value.value = yaw_rate_in_degrees;
+
+  if(confidence == std::numeric_limits<double>::infinity()) {
+    object.z_angular_velocity.confidence.value = AngularSpeedConfidence::UNAVAILABLE;
+  } else {
+    confidence *= 180.0 / M_PI;
+    confidence *= etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;  // convert to degrees/s
+    // How stupid is this?!
+    static const std::map<double, uint8_t> confidence_map = {
+        {1.0, AngularSpeedConfidence::DEG_SEC_01},
+        {2.0, AngularSpeedConfidence::DEG_SEC_02},
+        {5.0, AngularSpeedConfidence::DEG_SEC_05},
+        {10.0, AngularSpeedConfidence::DEG_SEC_10},
+        {20.0, AngularSpeedConfidence::DEG_SEC_20},
+        {50.0, AngularSpeedConfidence::DEG_SEC_50},
+        {std::numeric_limits<double>::infinity(), AngularSpeedConfidence::OUT_OF_RANGE},
+    };
+    for(const auto& [thresh, conf_val] : confidence_map) {
+      if (confidence <= thresh) {
+        object.z_angular_velocity.confidence.value = conf_val;
+        break;
+      }
     }
   }
-  object.z_angular_velocity.value.value = yaw_rate_in_degrees;
-  object.z_angular_velocity.confidence.value = confidence;
+
   object.z_angular_velocity_is_present = true;
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
@@ -150,22 +150,24 @@ inline void setMeasurementDeltaTimeOfPerceivedObject(PerceivedObject& object, co
  * @param value The value to be set in centimeters.
  * @param confidence The confidence to be set in centimeters (default: CoordinateConfidence::UNAVAILABLE).
  */
-inline void setCartesianCoordinateWithConfidence(CartesianCoordinateWithConfidence& coordinate, const int32_t value,
-                                                 const uint16_t confidence = CoordinateConfidence::UNAVAILABLE) {
+inline void setCartesianCoordinateWithConfidence(CartesianCoordinateWithConfidence& coordinate, const double value,
+                                                 const double confidence = std::numeric_limits<double>::infinity()) {
   // limit value range
   if (value < CartesianCoordinateLarge::NEGATIVE_OUT_OF_RANGE) {
     coordinate.value.value = CartesianCoordinateLarge::NEGATIVE_OUT_OF_RANGE;
   } else if (value > CartesianCoordinateLarge::POSITIVE_OUT_OF_RANGE) {
     coordinate.value.value = CartesianCoordinateLarge::POSITIVE_OUT_OF_RANGE;
   } else {
-    coordinate.value.value = value;
+    coordinate.value.value = static_cast<int32_t>(value);
   }
 
   // limit confidence range
-  if (confidence > CoordinateConfidence::MAX || confidence < CoordinateConfidence::MIN) {
+  if (confidence == std::numeric_limits<double>::infinity()) {
+    coordinate.confidence.value = CoordinateConfidence::UNAVAILABLE;
+  } else if (confidence > CoordinateConfidence::MAX || confidence < CoordinateConfidence::MIN) {
     coordinate.confidence.value = CoordinateConfidence::OUT_OF_RANGE;
   } else {
-    coordinate.confidence.value = confidence;
+    coordinate.confidence.value = static_cast<uint16_t>(confidence);
   }
 }
 
@@ -181,9 +183,9 @@ inline void setCartesianCoordinateWithConfidence(CartesianCoordinateWithConfiden
  * @param z_confidence The confidence value in meters for the z-coordinate (default: CoordinateConfidence::UNAVAILABLE).
  */
 inline void setPositionOfPerceivedObject(PerceivedObject& object, const gm::Point& point,
-                                         const double x_confidence = CoordinateConfidence::UNAVAILABLE,
-                                         const double y_confidence = CoordinateConfidence::UNAVAILABLE,
-                                         const double z_confidence = CoordinateConfidence::UNAVAILABLE) {
+                                         const double x_confidence = std::numeric_limits<double>::infinity(),
+                                         const double y_confidence = std::numeric_limits<double>::infinity(),
+                                         const double z_confidence = std::numeric_limits<double>::infinity()) {
   setCartesianCoordinateWithConfidence(object.position.x_coordinate, point.x * 100, x_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   setCartesianCoordinateWithConfidence(object.position.y_coordinate, point.y * 100, y_confidence * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   if (point.z != 0.0) {
@@ -209,9 +211,9 @@ inline void setPositionOfPerceivedObject(PerceivedObject& object, const gm::Poin
  */
 inline void setUTMPositionOfPerceivedObject(CollectivePerceptionMessage& cpm, PerceivedObject& object,
                                             const gm::PointStamped& utm_position,
-                                            const double x_confidence = CoordinateConfidence::UNAVAILABLE,
-                                            const double y_confidence = CoordinateConfidence::UNAVAILABLE,
-                                            const double z_confidence = CoordinateConfidence::UNAVAILABLE) {
+                                            const double x_confidence = std::numeric_limits<double>::infinity(),
+                                            const double y_confidence = std::numeric_limits<double>::infinity(),
+                                            const double z_confidence = std::numeric_limits<double>::infinity()) {
   gm::PointStamped reference_position = getUTMPosition(cpm);
   if (utm_position.header.frame_id != reference_position.header.frame_id) {
     throw std::invalid_argument("UTM-Position frame_id (" + utm_position.header.frame_id +
@@ -444,21 +446,24 @@ inline void setYawRateOfPerceivedObject(PerceivedObject& object, const double ya
  * @param value The value of the object dimension in decimeters.
  * @param confidence The confidence of the object dimension in decimeters (optional, default is ObjectDimensionConfidence::UNAVAILABLE).
  */
-inline void setObjectDimension(ObjectDimension& dimension, const uint16_t value,
-                               const uint8_t confidence = ObjectDimensionConfidence::UNAVAILABLE) {
+inline void setObjectDimension(ObjectDimension& dimension, const double value,
+                               const double confidence = std::numeric_limits<double>::infinity()) {
   // limit value range
   if (value < ObjectDimensionValue::MIN || value > ObjectDimensionValue::MAX) {
     dimension.value.value = ObjectDimensionValue::OUT_OF_RANGE;
   } else {
-    dimension.value.value = value;
+    dimension.value.value = static_cast<uint16_t>(value);
   }
 
   // limit confidence range
-  if (confidence > ObjectDimensionConfidence::MAX || confidence < ObjectDimensionConfidence::MIN) {
+  if (confidence == std::numeric_limits<double>::infinity()) {
+    dimension.confidence.value = ObjectDimensionConfidence::UNAVAILABLE;
+  } else   if (confidence > ObjectDimensionConfidence::MAX || confidence < ObjectDimensionConfidence::MIN) {
     dimension.confidence.value = ObjectDimensionConfidence::OUT_OF_RANGE;
   } else {
-    dimension.confidence.value = confidence;
+    dimension.confidence.value = static_cast<uint8_t>(confidence);
   }
+
 }
 
 /**
@@ -473,7 +478,7 @@ inline void setObjectDimension(ObjectDimension& dimension, const uint16_t value,
  */
 inline void setXDimensionOfPerceivedObject(PerceivedObject& object, const double value,
                                            const double confidence = ObjectDimensionConfidence::UNAVAILABLE) {
-  setObjectDimension(object.object_dimension_x, static_cast<uint16_t>(value * 10), static_cast<uint8_t>(confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR));
+  setObjectDimension(object.object_dimension_x, value * 10, confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   object.object_dimension_x_is_present = true;
 }
 
@@ -489,7 +494,7 @@ inline void setXDimensionOfPerceivedObject(PerceivedObject& object, const double
  */
 inline void setYDimensionOfPerceivedObject(PerceivedObject& object, const double value,
                                            const double confidence = ObjectDimensionConfidence::UNAVAILABLE) {
-  setObjectDimension(object.object_dimension_y, static_cast<uint16_t>(value * 10), static_cast<uint8_t>(confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR));
+  setObjectDimension(object.object_dimension_y, value * 10, confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   object.object_dimension_y_is_present = true;
 }
 
@@ -505,7 +510,7 @@ inline void setYDimensionOfPerceivedObject(PerceivedObject& object, const double
  */
 inline void setZDimensionOfPerceivedObject(PerceivedObject& object, const double value,
                                            const double confidence = ObjectDimensionConfidence::UNAVAILABLE) {
-  setObjectDimension(object.object_dimension_z, static_cast<uint16_t>(value * 10), static_cast<uint8_t>(confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR));
+  setObjectDimension(object.object_dimension_z, value * 10, confidence * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
   object.object_dimension_z_is_present = true;
 }
 
@@ -521,9 +526,9 @@ inline void setZDimensionOfPerceivedObject(PerceivedObject& object, const double
  * @param z_confidence The standard deviation in meters for the z dimension (optional, default: ObjectDimensionConfidence::UNAVAILABLE).
  */
 inline void setDimensionsOfPerceivedObject(PerceivedObject& object, const gm::Vector3& dimensions,
-                                           const double x_confidence = ObjectDimensionConfidence::UNAVAILABLE,
-                                           const double y_confidence = ObjectDimensionConfidence::UNAVAILABLE,
-                                           const double z_confidence = ObjectDimensionConfidence::UNAVAILABLE) {
+                                           const double x_confidence = std::numeric_limits<double>::infinity(),
+                                           const double y_confidence = std::numeric_limits<double>::infinity(),
+                                           const double z_confidence = std::numeric_limits<double>::infinity()) {
   setXDimensionOfPerceivedObject(object, dimensions.x, x_confidence);
   setYDimensionOfPerceivedObject(object, dimensions.y, y_confidence);
   setZDimensionOfPerceivedObject(object, dimensions.z, z_confidence);

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
@@ -209,9 +209,9 @@ inline void setPositionOfPerceivedObject(PerceivedObject& object, const gm::Poin
  */
 inline void setUTMPositionOfPerceivedObject(CollectivePerceptionMessage& cpm, PerceivedObject& object,
                                             const gm::PointStamped& utm_position,
-                                            const uint16_t x_confidence = CoordinateConfidence::UNAVAILABLE,
-                                            const uint16_t y_confidence = CoordinateConfidence::UNAVAILABLE,
-                                            const uint16_t z_confidence = CoordinateConfidence::UNAVAILABLE) {
+                                            const double x_confidence = CoordinateConfidence::UNAVAILABLE,
+                                            const double y_confidence = CoordinateConfidence::UNAVAILABLE,
+                                            const double z_confidence = CoordinateConfidence::UNAVAILABLE) {
   gm::PointStamped reference_position = getUTMPosition(cpm);
   if (utm_position.header.frame_id != reference_position.header.frame_id) {
     throw std::invalid_argument("UTM-Position frame_id (" + utm_position.header.frame_id +
@@ -219,12 +219,12 @@ inline void setUTMPositionOfPerceivedObject(CollectivePerceptionMessage& cpm, Pe
                                 ")");
   }
   setCartesianCoordinateWithConfidence(object.position.x_coordinate,
-                                       (utm_position.point.x - reference_position.point.x) * 100, x_confidence);
+                                       (utm_position.point.x - reference_position.point.x) * 100, x_confidence * 100);
   setCartesianCoordinateWithConfidence(object.position.y_coordinate,
-                                       (utm_position.point.y - reference_position.point.y) * 100, y_confidence);
+                                       (utm_position.point.y - reference_position.point.y) * 100, y_confidence * 100);
   if (utm_position.point.z != 0.0) {
     setCartesianCoordinateWithConfidence(object.position.z_coordinate,
-                                         (utm_position.point.z - reference_position.point.z) * 100, z_confidence);
+                                         (utm_position.point.z - reference_position.point.z) * 100, z_confidence * 100);
     object.position.z_coordinate_is_present = true;
   }
 }

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
@@ -362,10 +362,10 @@ inline void setAccelerationOfPerceivedObject(PerceivedObject& object, const gm::
  */
 inline void setYawOfPerceivedObject(PerceivedObject& object, const double yaw,
                                     double yaw_std = std::numeric_limits<double>::infinity()) {
-  // wrap angle to range [0, 360]
+  // wrap angle to range [0, 360)
   double yaw_in_degrees = yaw * 180 / M_PI;
-  while (yaw_in_degrees > 360.0) yaw_in_degrees -= 360.0;
-  while (yaw_in_degrees <= 0.0) yaw_in_degrees += 360.0;
+  while (yaw_in_degrees >= 360.0) yaw_in_degrees -= 360.0;
+  while (yaw_in_degrees < 0.0) yaw_in_degrees += 360.0;
   object.angles.z_angle.value.value = yaw_in_degrees * 10;
 
   if(yaw_std == std::numeric_limits<double>::infinity()) {

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_utils.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_utils.h
@@ -29,8 +29,6 @@ SOFTWARE.
  * @brief Utility functions for the ETSI ITS CPM (TS)
  */
 
-#include <etsi_its_msgs_utils/impl/constants.h>
-
 #pragma once
 
 /**

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_getters.h
@@ -101,7 +101,7 @@ inline double getAltitude(const DENM& denm) { return getAltitude(denm.denm.manag
 inline double getHeading(const DENM& denm) {
   if (denm.denm.location_is_present) {
     if (denm.denm.location.event_position_heading_is_present) {
-      return getHeadingInternal(denm.denm.location.event_position_heading);
+      return getHeadingCDD(denm.denm.location.event_position_heading);
     } else {
       throw std::invalid_argument("Heading is not present!");
     }
@@ -154,6 +154,17 @@ inline bool getIsSpeedPresent(const DENM& denm) {
   } else {
     throw std::invalid_argument("LocationContainer is not present!");
   }
+}
+
+/**
+ * @brief Get the Speed Confidence
+ * 
+ * @param denm DENM to get the Speed Confidence from
+ * @return double standard deviation of the speed in m/s as decimal number
+ */
+inline double getSpeedConfidence(const DENM& denm) {
+  return getSpeedConfidence(
+    denm.denm.location.event_speed);
 }
 
 /**

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_getters.h
@@ -93,16 +93,6 @@ inline double getLongitude(const DENM& denm) { return getLongitude(denm.denm.man
 inline double getAltitude(const DENM& denm) { return getAltitude(denm.denm.management.event_position.altitude); }
 
 /**
- * @brief Get the Heading value
- *
- * 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West
- *
- * @param heading to get the Heading value from
- * @return Heading value in degree as decimal number
- */
-inline double getHeading(const Heading& heading) { return ((double)heading.heading_value.value) * 1e-1; }
-
-/**
  * @brief Get the Heading object
  * 
  * @param denm DENM to get the Heading-Value from
@@ -111,7 +101,7 @@ inline double getHeading(const Heading& heading) { return ((double)heading.headi
 inline double getHeading(const DENM& denm) {
   if (denm.denm.location_is_present) {
     if (denm.denm.location.event_position_heading_is_present) {
-      return getHeading(denm.denm.location.event_position_heading);
+      return getHeadingInternal(denm.denm.location.event_position_heading);
     } else {
       throw std::invalid_argument("Heading is not present!");
     }

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_getters.h
@@ -96,12 +96,30 @@ inline double getAltitude(const DENM& denm) { return getAltitude(denm.denm.manag
  * @brief Get the Heading object
  * 
  * @param denm DENM to get the Heading-Value from
- * @return getHeading value
+ * @return heading value in degree as decimal number
  */
 inline double getHeading(const DENM& denm) {
   if (denm.denm.location_is_present) {
     if (denm.denm.location.event_position_heading_is_present) {
       return getHeadingCDD(denm.denm.location.event_position_heading);
+    } else {
+      throw std::invalid_argument("Heading is not present!");
+    }
+  } else {
+    throw std::invalid_argument("LocationContainer is not present!");
+  }
+}
+
+/**
+ * @brief Get the Heading confidence
+ * 
+ * @param denm DENM to get the Heading-Value from
+ * @return standard deviation of heading in degrees as decimal number
+ */
+inline double getHeadingConfidence(const DENM& denm) {
+  if (denm.denm.location_is_present) {
+    if (denm.denm.location.event_position_heading_is_present) {
+      return getHeadingConfidenceCDD(denm.denm.location.event_position_heading);
     } else {
       throw std::invalid_argument("Heading is not present!");
     }

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_setters.h
@@ -115,7 +115,7 @@ inline void setIsHeadingPresent(DENM& denm, bool presence_of_heading) {
  */
 inline void setHeading(DENM& denm, const double heading_val) {
   if (denm.denm.location_is_present) {
-    setHeading(denm.denm.location.event_position_heading, heading_val);
+    setHeadingInternal(denm.denm.location.event_position_heading, heading_val);
     setIsHeadingPresent(denm, true);
   } else {
     throw std::invalid_argument("LocationContainer is not present!");

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_setters.h
@@ -115,7 +115,7 @@ inline void setIsHeadingPresent(DENM& denm, bool presence_of_heading) {
  */
 inline void setHeading(DENM& denm, const double heading_val) {
   if (denm.denm.location_is_present) {
-    setHeadingInternal(denm.denm.location.event_position_heading, heading_val);
+    setHeadingCDD(denm.denm.location.event_position_heading, heading_val);
     setIsHeadingPresent(denm, true);
   } else {
     throw std::invalid_argument("LocationContainer is not present!");
@@ -141,8 +141,9 @@ inline void setIsSpeedPresent(DENM& denm, bool presence_of_speed) {
  *
  * @param denm DENM to set the speed value
  * @param speed_val speed value to set in m/s as decimal number
+ * @param confidence speed confidence value to set in m/s (default: infinity, mapping to SpeedConfidence::UNAVAILABLE)
  */
-inline void setSpeed(DENM& denm, const double speed_val, const double confidence = SpeedConfidence::UNAVAILABLE) {
+inline void setSpeed(DENM& denm, const double speed_val, const double confidence = std::numeric_limits<double>::infinity()) {
   if (denm.denm.location_is_present) {
     setSpeed(denm.denm.location.event_speed, speed_val, confidence);
     setIsSpeedPresent(denm, true);

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_setters.h
@@ -112,10 +112,11 @@ inline void setIsHeadingPresent(DENM& denm, bool presence_of_heading) {
  *
  * @param denm DENM to set the ReferencePosition
  * @param value Heading value in degree as decimal number
+ * @param confidence standard deviation of heading in degree as decimal number (default: infinity, mapping to HeadingConfidence::UNAVAILABLE)
  */
-inline void setHeading(DENM& denm, const double heading_val) {
+inline void setHeading(DENM& denm, const double heading_val, const double confidence = std::numeric_limits<double>::infinity()) {
   if (denm.denm.location_is_present) {
-    setHeadingCDD(denm.denm.location.event_position_heading, heading_val);
+    setHeadingCDD(denm.denm.location.event_position_heading, heading_val, confidence);
     setIsHeadingPresent(denm, true);
   } else {
     throw std::invalid_argument("LocationContainer is not present!");

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_setters.h
@@ -142,9 +142,9 @@ inline void setIsSpeedPresent(DENM& denm, bool presence_of_speed) {
  * @param denm DENM to set the speed value
  * @param speed_val speed value to set in m/s as decimal number
  */
-inline void setSpeed(DENM& denm, const double speed_val) {
+inline void setSpeed(DENM& denm, const double speed_val, const double confidence = SpeedConfidence::UNAVAILABLE) {
   if (denm.denm.location_is_present) {
-    setSpeed(denm.denm.location.event_speed, speed_val);
+    setSpeed(denm.denm.location.event_speed, speed_val, confidence);
     setIsSpeedPresent(denm, true);
   } else {
     throw std::invalid_argument("LocationContainer is not present!");

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/denm/denm_setters.h
@@ -91,34 +91,6 @@ inline void setReferencePosition(DENM& denm, const double latitude, const double
 }
 
 /**
- * @brief Set the HeadingValue object
- *
- * 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West
- *
- * @param heading object to set
- * @param value Heading value in degree as decimal number
- */
-inline void setHeadingValue(HeadingValue& heading, const double value) {
-  int64_t deg = (int64_t)std::round(value * 1e1);
-  throwIfOutOfRange(deg, HeadingValue::MIN, HeadingValue::MAX, "HeadingValue");
-  heading.value = deg;
-}
-
-/**
- * @brief Set the Heading object
- *
- * 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West
- * HeadingConfidence is set to UNAVAILABLE
- *
- * @param heading object to set
- * @param value Heading value in degree as decimal number
- */
-inline void setHeading(Heading& heading, const double value) {
-  heading.heading_confidence.value = HeadingConfidence::UNAVAILABLE;
-  setHeadingValue(heading.heading_value, value);
-}
-
-/**
  * @brief Set the IsHeadingPresent object for DENM
  * 
  * @param denm DENM to set IsHeadingPresent

--- a/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
@@ -74,8 +74,10 @@ TEST(etsi_its_cam_msgs, test_set_get_cam) {
   EXPECT_NEAR(altitude, cam_access::getAltitude(cam), 1e-2);
 
   double heading_val = randomDouble(0.0, 360.0);
-  cam_access::setHeading(cam, heading_val);
+  double heading_conf = randomDouble(0.0, 6.25);
+  cam_access::setHeading(cam, heading_val, heading_conf);
   EXPECT_NEAR(heading_val, cam_access::getHeading(cam), 1e-1);
+  EXPECT_NEAR(heading_conf, cam_access::getHeadingConfidence(cam), 1e-1);
 
   std::array<double, 4> covariance_matrix = {randomDouble(1.0, 100.0), 0.0,
     0.0, randomDouble(1.0, 100.0)};

--- a/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
@@ -132,6 +132,14 @@ TEST(etsi_its_cam_msgs, test_set_get_cam) {
   EXPECT_NEAR(covariance_matrix_rotated[2], cov_get_rotated[2], 1e-1);
   EXPECT_NEAR(covariance_matrix_rotated[3], cov_get_rotated[3], 1e-1);
 
+  // Set WGS84 confidence ellipse
+  cam_access::setWGSRefPosConfidence(cam, covariance_matrix_rotated);
+  cov_get_rotated = cam_access::getWGSRefPosConfidence(cam);
+  EXPECT_NEAR(covariance_matrix_rotated[0], cov_get_rotated[0], 1e-1);
+  EXPECT_NEAR(covariance_matrix_rotated[1], cov_get_rotated[1], 1e-1);
+  EXPECT_NEAR(covariance_matrix_rotated[2], cov_get_rotated[2], 1e-1);
+  EXPECT_NEAR(covariance_matrix_rotated[3], cov_get_rotated[3], 1e-1);
+
   double length = randomDouble(0.0, 102.2);
   double width = randomDouble(0.0, 6.2);
   cam_access::setVehicleDimensions(cam, length, width);

--- a/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
@@ -147,15 +147,21 @@ TEST(etsi_its_cam_msgs, test_set_get_cam) {
   EXPECT_NEAR(width, cam_access::getVehicleWidth(cam), 1e-1);
 
   double speed_val = randomDouble(0.0, 163.82);
-  cam_access::setSpeed(cam, speed_val);
+  double speed_conf = randomDouble(0.0, 0.625);
+  cam_access::setSpeed(cam, speed_val, speed_conf);
   EXPECT_NEAR(speed_val, cam_access::getSpeed(cam), 1e-2);
+  EXPECT_NEAR(speed_conf, cam_access::getSpeedConfidence(cam), 1e-2);
 
   double lon_accel = randomDouble(-16.0, 16.0);
   double lat_accel = randomDouble(-16.0, 16.0);
-  cam_access::setLongitudinalAcceleration(cam, lon_accel);
+  double lon_accel_conf = randomDouble(0.0, 5.0);
+  double lat_accel_conf = randomDouble(0.0, 5.0);
+  cam_access::setLongitudinalAcceleration(cam, lon_accel, lon_accel_conf);
   EXPECT_NEAR(lon_accel, cam_access::getLongitudinalAcceleration(cam), 1e-1);
-  cam_access::setLateralAcceleration(cam, lat_accel);
+  EXPECT_NEAR(lon_accel_conf, cam_access::getLongitudinalAccelerationConfidence(cam), 1e-1);
+  cam_access::setLateralAcceleration(cam, lat_accel, lat_accel_conf);
   EXPECT_NEAR(lat_accel, cam_access::getLateralAcceleration(cam), 1e-1);
+  EXPECT_NEAR(lat_accel_conf, cam_access::getLateralAccelerationConfidence(cam), 1e-1);
 
   std::vector<bool> exterior_lights(cam_msgs::ExteriorLights::SIZE_BITS);
   for (int i = 0; i < cam_msgs::ExteriorLights::SIZE_BITS; i++) {

--- a/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
@@ -99,7 +99,6 @@ TEST(etsi_its_cam_msgs, test_set_get_cam) {
   // Rotate the covariance matrix by a random angle
   // and repeat the test
   double phi = randomDouble(0.0, M_PI_2);
-  std::cerr << "phi: " << phi << std::endl;
   std::array<double, 4> covariance_matrix_rotated = {
     covariance_matrix[0] * std::cos(phi) * std::cos(phi) +
     covariance_matrix[3] * std::sin(phi) * std::sin(phi),

--- a/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
@@ -95,6 +95,11 @@ TEST(etsi_its_cam_msgs, test_set_get_cam) {
     expected_heading -= 180;
   }
   EXPECT_NEAR(expected_heading, cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse.semi_major_orientation.value/10.0, 1e-1);
+  auto cov_get = cam_access::getRefPosConfidence(cam);
+  EXPECT_NEAR(covariance_matrix[0], cov_get[0], 1e-1);
+  EXPECT_NEAR(covariance_matrix[1], cov_get[1], 1e-1);
+  EXPECT_NEAR(covariance_matrix[2], cov_get[2], 1e-1);
+  EXPECT_NEAR(covariance_matrix[3], cov_get[3], 1e-1);
 
   // Rotate the covariance matrix by a random angle
   // and repeat the test
@@ -121,6 +126,11 @@ TEST(etsi_its_cam_msgs, test_set_get_cam) {
     expected_heading -= 180;
   }
   EXPECT_NEAR(expected_heading, cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse.semi_major_orientation.value/10.0, 1e-1);
+  auto cov_get_rotated = cam_access::getRefPosConfidence(cam);
+  EXPECT_NEAR(covariance_matrix_rotated[0], cov_get_rotated[0], 1e-1);
+  EXPECT_NEAR(covariance_matrix_rotated[1], cov_get_rotated[1], 1e-1);
+  EXPECT_NEAR(covariance_matrix_rotated[2], cov_get_rotated[2], 1e-1);
+  EXPECT_NEAR(covariance_matrix_rotated[3], cov_get_rotated[3], 1e-1);
 
   double length = randomDouble(0.0, 102.2);
   double width = randomDouble(0.0, 6.2);

--- a/etsi_its_msgs_utils/test/impl/test_cam_ts_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cam_ts_access.cpp
@@ -74,8 +74,10 @@ TEST(etsi_its_cam_ts_msgs, test_set_get_cam) {
   EXPECT_NEAR(altitude, cam_ts_access::getAltitude(cam), 1e-2);
 
   double heading_val = randomDouble(0.0, 360.0);
-  cam_ts_access::setHeading(cam, heading_val);
+  double heading_conf = randomDouble(0.0, 6.25);
+  cam_ts_access::setHeading(cam, heading_val, heading_conf);
   EXPECT_NEAR(heading_val, cam_ts_access::getHeading(cam), 1e-1);
+  EXPECT_NEAR(heading_conf, cam_ts_access::getHeadingConfidence(cam), 1e-1);
 
   std::array<double, 4> covariance_matrix = {randomDouble(1.0, 100.0), 0.0,
     0.0, randomDouble(1.0, 100.0)};

--- a/etsi_its_msgs_utils/test/impl/test_cam_ts_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cam_ts_access.cpp
@@ -95,6 +95,11 @@ TEST(etsi_its_cam_ts_msgs, test_set_get_cam) {
     expected_heading -= 180;
   }
   EXPECT_NEAR(expected_heading, cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse.semi_major_axis_orientation.value/10.0, 1e-1);
+  auto cov_get = cam_ts_access::getRefPosConfidence(cam);
+  EXPECT_NEAR(covariance_matrix[0], cov_get[0], 1e-1);
+  EXPECT_NEAR(covariance_matrix[1], cov_get[1], 1e-1);
+  EXPECT_NEAR(covariance_matrix[2], cov_get[2], 1e-1);
+  EXPECT_NEAR(covariance_matrix[3], cov_get[3], 1e-1);
 
   // Rotate the covariance matrix by a random angle
   // and repeat the test
@@ -121,6 +126,11 @@ TEST(etsi_its_cam_ts_msgs, test_set_get_cam) {
     expected_heading -= 180;
   }
   EXPECT_NEAR(expected_heading, cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse.semi_major_axis_orientation.value/10.0, 1e-1);
+  auto cov_get_rotated = cam_ts_access::getRefPosConfidence(cam);
+  EXPECT_NEAR(covariance_matrix_rotated[0], cov_get_rotated[0], 1e-1);
+  EXPECT_NEAR(covariance_matrix_rotated[1], cov_get_rotated[1], 1e-1);
+  EXPECT_NEAR(covariance_matrix_rotated[2], cov_get_rotated[2], 1e-1);
+  EXPECT_NEAR(covariance_matrix_rotated[3], cov_get_rotated[3], 1e-1);
 
   double length = randomDouble(0.0, 102.2);
   double width = randomDouble(0.0, 6.2);

--- a/etsi_its_msgs_utils/test/impl/test_cam_ts_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cam_ts_access.cpp
@@ -132,6 +132,14 @@ TEST(etsi_its_cam_ts_msgs, test_set_get_cam) {
   EXPECT_NEAR(covariance_matrix_rotated[2], cov_get_rotated[2], 1e-1);
   EXPECT_NEAR(covariance_matrix_rotated[3], cov_get_rotated[3], 1e-1);
 
+  // Set WGS84 confidence ellipse
+  cam_ts_access::setWGSRefPosConfidence(cam, covariance_matrix_rotated);
+  cov_get_rotated = cam_ts_access::getWGSRefPosConfidence(cam);
+  EXPECT_NEAR(covariance_matrix_rotated[0], cov_get_rotated[0], 1e-1);
+  EXPECT_NEAR(covariance_matrix_rotated[1], cov_get_rotated[1], 1e-1);
+  EXPECT_NEAR(covariance_matrix_rotated[2], cov_get_rotated[2], 1e-1);
+  EXPECT_NEAR(covariance_matrix_rotated[3], cov_get_rotated[3], 1e-1);
+
   double length = randomDouble(0.0, 102.2);
   double width = randomDouble(0.0, 6.2);
   cam_ts_access::setVehicleDimensions(cam, length, width);

--- a/etsi_its_msgs_utils/test/impl/test_cam_ts_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cam_ts_access.cpp
@@ -147,15 +147,21 @@ TEST(etsi_its_cam_ts_msgs, test_set_get_cam) {
   EXPECT_NEAR(width, cam_ts_access::getVehicleWidth(cam), 1e-1);
 
   double speed_val = randomDouble(0.0, 163.82);
-  cam_ts_access::setSpeed(cam, speed_val);
+  double speed_conf = randomDouble(0.0, 0.625);
+  cam_ts_access::setSpeed(cam, speed_val, speed_conf);
   EXPECT_NEAR(speed_val, cam_ts_access::getSpeed(cam), 1e-2);
+  EXPECT_NEAR(speed_conf, cam_ts_access::getSpeedConfidence(cam), 1e-2);
 
   double lon_accel = randomDouble(-16.0, 16.0);
   double lat_accel = randomDouble(-16.0, 16.0);
-  cam_ts_access::setLongitudinalAcceleration(cam, lon_accel);
+  double lon_accel_conf = randomDouble(0.0, 5.0);
+  double lat_accel_conf = randomDouble(0.0, 5.0);
+  cam_ts_access::setLongitudinalAcceleration(cam, lon_accel, lon_accel_conf);
   EXPECT_NEAR(lon_accel, cam_ts_access::getLongitudinalAcceleration(cam), 1e-1);
-  cam_ts_access::setLateralAcceleration(cam, lat_accel);
+  EXPECT_NEAR(lon_accel_conf, cam_ts_access::getLongitudinalAccelerationConfidence(cam), 1e-1);
+  cam_ts_access::setLateralAcceleration(cam, lat_accel, lat_accel_conf);
   EXPECT_NEAR(lat_accel, cam_ts_access::getLateralAcceleration(cam), 1e-1);
+  EXPECT_NEAR(lat_accel_conf, cam_ts_access::getLateralAccelerationConfidence(cam), 1e-1);
 
   std::vector<bool> exterior_lights(cam_ts_msgs::ExteriorLights::SIZE_BITS);
   for (int i = 0; i < cam_ts_msgs::ExteriorLights::SIZE_BITS; i++) {

--- a/etsi_its_msgs_utils/test/impl/test_cam_ts_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cam_ts_access.cpp
@@ -77,6 +77,51 @@ TEST(etsi_its_cam_ts_msgs, test_set_get_cam) {
   cam_ts_access::setHeading(cam, heading_val);
   EXPECT_NEAR(heading_val, cam_ts_access::getHeading(cam), 1e-1);
 
+  std::array<double, 4> covariance_matrix = {randomDouble(1.0, 100.0), 0.0,
+    0.0, randomDouble(1.0, 100.0)};
+  // Make y component larger than x component so the ellipse will have its major axis 90° rotated
+  covariance_matrix[3] += covariance_matrix[0]; 
+  cam_ts_access::setRefPosConfidence(cam, covariance_matrix, heading_val * M_PI / 180.0);
+  EXPECT_NEAR(heading_val, cam_ts_access::getHeading(cam), 1e-1);
+  EXPECT_NEAR(covariance_matrix[3], std::pow( cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse.semi_major_axis_length.value*0.01 / etsi_its_msgs::TWO_D_GAUSSIAN_FACTOR, 2), 1e-1);
+  EXPECT_NEAR(covariance_matrix[0], std::pow( cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse.semi_minor_axis_length.value*0.01 / etsi_its_msgs::TWO_D_GAUSSIAN_FACTOR, 2), 1e-1);
+  double expected_heading = heading_val + 90.0;
+  // Normalize to [0, 180)
+  expected_heading = std::fmod(expected_heading + 180, 180);
+  while (expected_heading < 0) {
+    expected_heading += 180;
+  }
+  while (expected_heading >= 180) {
+    expected_heading -= 180;
+  }
+  EXPECT_NEAR(expected_heading, cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse.semi_major_axis_orientation.value/10.0, 1e-1);
+
+  // Rotate the covariance matrix by a random angle
+  // and repeat the test
+  double phi = randomDouble(0.0, M_PI_2);
+  std::array<double, 4> covariance_matrix_rotated = {
+    covariance_matrix[0] * std::cos(phi) * std::cos(phi) +
+    covariance_matrix[3] * std::sin(phi) * std::sin(phi),
+    (covariance_matrix[0] - covariance_matrix[3]) * std::cos(phi) * std::sin(phi),
+    (covariance_matrix[0] - covariance_matrix[3]) * std::cos(phi) * std::sin(phi),
+    covariance_matrix[0] * std::sin(phi) * std::sin(phi) +
+    covariance_matrix[3] * std::cos(phi) * std::cos(phi)
+  };
+  cam_ts_access::setRefPosConfidence(cam, covariance_matrix_rotated, heading_val * M_PI / 180.0);
+  EXPECT_NEAR(heading_val, cam_ts_access::getHeading(cam), 1e-1);
+  EXPECT_NEAR(covariance_matrix[3], std::pow( cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse.semi_major_axis_length.value*0.01 / etsi_its_msgs::TWO_D_GAUSSIAN_FACTOR, 2), 1e-1);
+  EXPECT_NEAR(covariance_matrix[0], std::pow( cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse.semi_minor_axis_length.value*0.01 / etsi_its_msgs::TWO_D_GAUSSIAN_FACTOR, 2), 1e-1);
+  expected_heading = heading_val - phi * 180.0 / M_PI + 90.0;
+  // Normalize to [0, 180)
+  expected_heading = std::fmod(expected_heading + 180, 180);
+  while (expected_heading < 0) {
+    expected_heading += 180;
+  }
+  while (expected_heading >= 180) {
+    expected_heading -= 180;
+  }
+  EXPECT_NEAR(expected_heading, cam.cam.cam_parameters.basic_container.reference_position.position_confidence_ellipse.semi_major_axis_orientation.value/10.0, 1e-1);
+
   double length = randomDouble(0.0, 102.2);
   double width = randomDouble(0.0, 6.2);
   cam_ts_access::setVehicleDimensions(cam, length, width);

--- a/etsi_its_msgs_utils/test/impl/test_cpm_ts_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cpm_ts_access.cpp
@@ -83,23 +83,37 @@ TEST(etsi_its_cpm_ts_msgs, test_set_get_cpm) {
   double dy = randomDouble(-10.0, 10.0);
   utm.point.x += dx;
   utm.point.y += dy;
-  cpm_ts_access::setUTMPositionOfPerceivedObject(cpm, object, utm);
+  double var_x = randomDouble(0.1, 20.48);
+  double var_y = randomDouble(0.1, 20.48);
+  double var_z = randomDouble(0.1, 20.48);
+  cpm_ts_access::setUTMPositionOfPerceivedObject(cpm, object, utm, var_x, var_y, var_z);
   gm::PointStamped point = cpm_ts_access::getUTMPositionOfPerceivedObject(cpm, object);
   EXPECT_NEAR(utm.point.x, point.point.x, 1e-1);
   EXPECT_NEAR(utm.point.y, point.point.y, 1e-1);
   gm::Point dpoint = cpm_ts_access::getPositionOfPerceivedObject(object);
   EXPECT_NEAR(dx, dpoint.x, 1e-1);
   EXPECT_NEAR(dy, dpoint.y, 1e-1);
+  auto [var_x_get, var_y_get, var_z_get] = cpm_ts_access::getPositionConfidenceOfPerceivedObject(object);
+  EXPECT_NEAR(var_x, var_x_get, 1e-2);
+  EXPECT_NEAR(var_y, var_y_get, 1e-2);
+  EXPECT_NEAR(var_z, var_z_get, 1e-2);
 
 
   gm::Vector3 dimensions;
   dimensions.x = randomDouble(0.1, 25.6);
   dimensions.y = randomDouble(0.1, 25.6);
   dimensions.z = randomDouble(0.1, 25.6);
-  cpm_ts_access::setDimensionsOfPerceivedObject(object, dimensions);
+  var_x = randomDouble(0.1, 1.5);
+  var_y = randomDouble(0.1, 1.5);
+  var_z = randomDouble(0.1, 1.5);
+  cpm_ts_access::setDimensionsOfPerceivedObject(object, dimensions, var_x, var_y, var_z);
   EXPECT_NEAR(dimensions.x, cpm_ts_access::getDimensionsOfPerceivedObject(object).x, 1e-1);
   EXPECT_NEAR(dimensions.y, cpm_ts_access::getDimensionsOfPerceivedObject(object).y, 1e-1);
   EXPECT_NEAR(dimensions.z, cpm_ts_access::getDimensionsOfPerceivedObject(object).z, 1e-1);
+  std::tie(var_x_get, var_y_get, var_z_get) = cpm_ts_access::getDimensionsConfidenceOfPerceivedObject(object);
+  EXPECT_NEAR(var_x, var_x_get, 1e-1);
+  EXPECT_NEAR(var_y, var_y_get, 1e-1);
+  EXPECT_NEAR(var_z, var_z_get, 1e-1);
 
   gm::Vector3 velocity;
   velocity.x = randomDouble(-163.83, 163.83);

--- a/etsi_its_msgs_utils/test/impl/test_cpm_ts_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cpm_ts_access.cpp
@@ -78,11 +78,15 @@ TEST(etsi_its_cpm_ts_msgs, test_set_get_cpm) {
   EXPECT_NEAR(longitude, cpm_ts_access::getLongitude(cpm), 1e-7);
   EXPECT_NEAR(altitude, cpm_ts_access::getAltitude(cpm), 1e-2);
 
+  // Test perceived object
+  // Position
   cpm_ts_msgs::PerceivedObject object;
-  double dx = randomDouble(-10.0, 10.0);;
+  double dx = randomDouble(-10.0, 10.0);
   double dy = randomDouble(-10.0, 10.0);
+  double dz = randomDouble(-10.0, 10.0);
   utm.point.x += dx;
   utm.point.y += dy;
+  utm.point.z += dz;
   double var_x = randomDouble(0.1, 20.48);
   double var_y = randomDouble(0.1, 20.48);
   double var_z = randomDouble(0.1, 20.48);
@@ -90,15 +94,17 @@ TEST(etsi_its_cpm_ts_msgs, test_set_get_cpm) {
   gm::PointStamped point = cpm_ts_access::getUTMPositionOfPerceivedObject(cpm, object);
   EXPECT_NEAR(utm.point.x, point.point.x, 1e-1);
   EXPECT_NEAR(utm.point.y, point.point.y, 1e-1);
+  EXPECT_NEAR(utm.point.z, point.point.z, 1e-1);
   gm::Point dpoint = cpm_ts_access::getPositionOfPerceivedObject(object);
   EXPECT_NEAR(dx, dpoint.x, 1e-1);
   EXPECT_NEAR(dy, dpoint.y, 1e-1);
+  EXPECT_NEAR(dz, dpoint.z, 1e-1);
   auto [var_x_get, var_y_get, var_z_get] = cpm_ts_access::getPositionConfidenceOfPerceivedObject(object);
   EXPECT_NEAR(var_x, var_x_get, 1e-2);
   EXPECT_NEAR(var_y, var_y_get, 1e-2);
   EXPECT_NEAR(var_z, var_z_get, 1e-2);
 
-
+  // Dimensions
   gm::Vector3 dimensions;
   dimensions.x = randomDouble(0.1, 25.6);
   dimensions.y = randomDouble(0.1, 25.6);
@@ -115,21 +121,56 @@ TEST(etsi_its_cpm_ts_msgs, test_set_get_cpm) {
   EXPECT_NEAR(var_y, var_y_get, 1e-1);
   EXPECT_NEAR(var_z, var_z_get, 1e-1);
 
+  // Yaw
+  double yaw = randomDouble(-M_PI, M_PI);
+  double yaw_std = randomDouble(0.0001, 0.109);
+  cpm_ts_access::setYawOfPerceivedObject(object, yaw, yaw_std);
+  EXPECT_NEAR(yaw, cpm_ts_access::getYawOfPerceivedObject(object), 1e-1 * M_PI / 180.0);
+  EXPECT_NEAR(yaw_std, cpm_ts_access::getYawConfidenceOfPerceivedObject(object), 1e-1 * M_PI / 180.0);
+
+  // Yaw rate
+  double yaw_rate = randomDouble(-4.45, 4.45);
+  double yaw_rate_std = randomDouble(0.0001, 0.436);
+  cpm_ts_access::setYawRateOfPerceivedObject(object, yaw_rate, yaw_rate_std);
+  EXPECT_NEAR(yaw_rate, cpm_ts_access::getYawRateOfPerceivedObject(object), 1e0 * M_PI / 180.0);
+  std::array<double, 6> yaw_std_possible_values{1.0, 2.0, 5.0, 10.0, 20.0, 50.0};
+  std::for_each(yaw_std_possible_values.begin(), yaw_std_possible_values.end(),
+                [](double& val) { val *= 0.5 * M_PI / 180.0; });
+  double expected_yaw_rate = *std::lower_bound(yaw_std_possible_values.begin(), yaw_std_possible_values.end(), yaw_rate_std);
+  EXPECT_NEAR(expected_yaw_rate, cpm_ts_access::getYawRateConfidenceOfPerceivedObject(object), 1e0 * M_PI / 180.0);
+
+
+  // Velocity
   gm::Vector3 velocity;
   velocity.x = randomDouble(-163.83, 163.83);
   velocity.y = randomDouble(-163.83, 163.83);
   velocity.z = randomDouble(-163.83, 163.83);
-  cpm_ts_access::setVelocityOfPerceivedObject(object, velocity);
+  double velocity_x_std = randomDouble(0.01, 0.625);
+  double velocity_y_std = randomDouble(0.01, 0.625);
+  double velocity_z_std = randomDouble(0.01, 0.625);
+  cpm_ts_access::setVelocityOfPerceivedObject(object, velocity, velocity_x_std, velocity_y_std, velocity_z_std);
   EXPECT_NEAR(velocity.x, cpm_ts_access::getCartesianVelocityOfPerceivedObject(object).x, 1e-2);
   EXPECT_NEAR(velocity.y, cpm_ts_access::getCartesianVelocityOfPerceivedObject(object).y, 1e-2);
   EXPECT_NEAR(velocity.z, cpm_ts_access::getCartesianVelocityOfPerceivedObject(object).z, 1e-2);
+  auto [vel_x_std_get, vel_y_std_get, vel_z_std_get] = cpm_ts_access::getCartesianVelocityConfidenceOfPerceivedObject(object);
+  EXPECT_NEAR(velocity_x_std, vel_x_std_get, 1e-2);
+  EXPECT_NEAR(velocity_y_std, vel_y_std_get, 1e-2);
+  EXPECT_NEAR(velocity_z_std, vel_z_std_get, 1e-2);
 
+  // Acceleration
   gm::Vector3 acceleration;
   acceleration.x = randomDouble(-16.0, 16.0);
   acceleration.y = randomDouble(-16.0, 16.0);
   acceleration.z = randomDouble(-16.0, 16.0);
-  cpm_ts_access::setAccelerationOfPerceivedObject(object, acceleration);
+  double acceleration_x_std = randomDouble(0.1, 5.0);
+  double acceleration_y_std = randomDouble(0.1, 5.0);
+  double acceleration_z_std = randomDouble(0.1, 5.0);
+  cpm_ts_access::setAccelerationOfPerceivedObject(object, acceleration, acceleration_x_std, acceleration_y_std, acceleration_z_std);
   EXPECT_NEAR(acceleration.x, cpm_ts_access::getCartesianAccelerationOfPerceivedObject(object).x, 1e-1);
   EXPECT_NEAR(acceleration.y, cpm_ts_access::getCartesianAccelerationOfPerceivedObject(object).y, 1e-1);
   EXPECT_NEAR(acceleration.z, cpm_ts_access::getCartesianAccelerationOfPerceivedObject(object).z, 1e-1);
+  auto [acc_x_std_get, acc_y_std_get, acc_z_std_get] = cpm_ts_access::getCartesianAccelerationConfidenceOfPerceivedObject(object);
+  EXPECT_NEAR(acceleration_x_std, acc_x_std_get, 1e-1);
+  EXPECT_NEAR(acceleration_y_std, acc_y_std_get, 1e-1);
+  EXPECT_NEAR(acceleration_z_std, acc_z_std_get, 1e-1);
 }

--- a/etsi_its_msgs_utils/test/impl/test_denm_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_denm_access.cpp
@@ -65,9 +65,11 @@ TEST(etsi_its_denm_msgs, test_set_get_denm) {
   EXPECT_NEAR(altitude, denm_access::getAltitude(denm), 1e-2);
 
   double heading_val = randomDouble(0.0, 360.0);
+  double heading_conf = randomDouble(0.0, 6.25);
   denm.denm.location_is_present = true;
-  denm_access::setHeading(denm, heading_val);
+  denm_access::setHeading(denm, heading_val, heading_conf);
   EXPECT_NEAR(heading_val, denm_access::getHeading(denm), 1e-1);
+  EXPECT_NEAR(heading_conf, denm_access::getHeadingConfidence(denm), 1e-1);
 
   double speed_val = randomDouble(0.0, 163.82);
   denm.denm.location_is_present = true;

--- a/etsi_its_msgs_utils/test/impl/test_spatem_ts_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_spatem_ts_access.cpp
@@ -83,7 +83,7 @@ TEST(etsi_its_spatem_ts_msgs, test_set_get_spatem) {
   int random_int_time2 = randomInt(0, 35990);
   int random_int_seconds2 = randomInt(0, 3599);
   uint random_uint_nanosecs2 = (uint)randomInt(0, 1e3 - 1) * 1e6;
-  double tolerance = 1e-4;
+  double tolerance = 1e-3;
 
   float time_mark_as_seconds2 = spatem_ts_access::interpretTimeMarkValueAsSeconds(random_int_time2, random_int_seconds2, random_uint_nanosecs2);
   EXPECT_NEAR(time_mark_as_seconds2, (float)random_int_time2 * 0.1f - (random_int_seconds2 + (float)random_uint_nanosecs2 * 1e-9), tolerance);

--- a/etsi_its_msgs_utils/test/impl/test_spatem_ts_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_spatem_ts_access.cpp
@@ -83,7 +83,7 @@ TEST(etsi_its_spatem_ts_msgs, test_set_get_spatem) {
   int random_int_time2 = randomInt(0, 35990);
   int random_int_seconds2 = randomInt(0, 3599);
   uint random_uint_nanosecs2 = (uint)randomInt(0, 1e3 - 1) * 1e6;
-  double tolerance = 1e-3;
+  double tolerance = 1e-4;
 
   float time_mark_as_seconds2 = spatem_ts_access::interpretTimeMarkValueAsSeconds(random_int_time2, random_int_seconds2, random_uint_nanosecs2);
   EXPECT_NEAR(time_mark_as_seconds2, (float)random_int_time2 * 0.1f - (random_int_seconds2 + (float)random_uint_nanosecs2 * 1e-9), tolerance);


### PR DESCRIPTION
This PR adds the following features:
- Setters for Pos(ition)ConfidenceEllipse from UTM or vehicle-aligned covariance matrices for CAM, CAM_TS and DENM reference position
- Setters for other CAM, CAM_TS and CPM quantities' confidences from standard deviations, as additional argument in the setters
- Respective getters for all of them
- Tests, that also demonstrate how to use the functions

Breaking changes:
- The default argument for all confidence setters is changed to `std::numeric_limits<double>::infinity()` as this is internally converted to the units stored inside the ETSI messages. Infinity will still be converted to UNAVAILABLE, OUT_OF_RANGE, or similar, depending on the exact type.
- The function `getYawRateOfPerceivedObject` for CPM objects now returns the yaw rate as rad/s instead of deg/s - aligned with the setter.

Side notes:
- The old setters already could set confidences, although they were given directly as int types, so not really useful
- Renamed the `setHeading` methods not acting on an entire message (like CAM or DENM) to `setHeadingCDD` and made it a template, so it only needs to be implemented once in the CDD
- Removed a random +180° in the CPM perceived object setYaw function

Possible future work:
- Handle positions/speeds/accelerations of CPM perceived objects that are not given as xyz
- Add getters and setters for non-main-diagonal covariance matrix entries in CPM perceived objects