### PR TITLE
prevent infinite recursion checking constraint of ItsPduHeaderVam

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,6 @@ rosrun nodelet nodelet standalone etsi_its_conversion/Converter _etsi_types:=[ca
 | `udp2ros_etsi_types` | `string[]` | list of ETSI types to convert from `udp_msgs` to `etsi_its_msgs` (defaults to all supported ETSI types, either EN or TS version)  | `cam`, `cam_ts`, `cpm_ts`, `denm`, `denm_ts`, `mapem_ts`, `mcm_uulm`, `spatem_ts`, `vam_ts` |
 | `subscriber_queue_size` | `int` | queue size for incoming ROS messages |
 | `publisher_queue_size` | `int` | queue size for outgoing ROS messages |
-| `check_constraints_before_encoding` | `bool` | whether an asn constraint check should be performed before encoding using asn1c's `asn_check_constraints` function (setting to `true` could lead to segmentation faults because of infinite recursion; [known asn1c issue](https://github.com/vlm/asn1c/issues/410)) |
 
 
 ## Sample Messages

--- a/etsi_its_coding/etsi_its_vam_ts_coding/src/vam_ts_ItsPduHeaderVam.c
+++ b/etsi_its_coding/etsi_its_vam_ts_coding/src/vam_ts_ItsPduHeaderVam.c
@@ -23,7 +23,12 @@ vam_ts_ItsPduHeaderVam_constraint(const asn_TYPE_descriptor_t *td, const void *s
 		/* Nothing is here. See below */
 	}
 	
-	return td->encoding_constraints.general_constraints(td, sptr, ctfailcb, app_key);
+	/* prevent infinite recursion */
+	if (td->encoding_constraints.general_constraints != vam_ts_ItsPduHeaderVam_constraint) {
+		return td->encoding_constraints.general_constraints(td, sptr, ctfailcb, app_key);
+	} else {
+		return 0;
+	}
 }
 
 /*

--- a/etsi_its_conversion/etsi_its_conversion/config/params.ros1.yml
+++ b/etsi_its_conversion/etsi_its_conversion/config/params.ros1.yml
@@ -21,4 +21,3 @@ udp2ros_etsi_types:
   - vam_ts
 subscriber_queue_size: 10
 publisher_queue_size: 10
-check_constraints_before_encoding: false # setting to true could lead to segmentation faults because of infinite recursion (https://github.com/vlm/asn1c/issues/410)

--- a/etsi_its_conversion/etsi_its_conversion/config/params.yml
+++ b/etsi_its_conversion/etsi_its_conversion/config/params.yml
@@ -23,4 +23,3 @@
       - vam_ts
     subscriber_queue_size: 10
     publisher_queue_size: 10
-    check_constraints_before_encoding: false # setting to true could lead to segmentation faults because of infinite recursion (https://github.com/vlm/asn1c/issues/410)

--- a/etsi_its_conversion/etsi_its_conversion/include/etsi_its_conversion/Converter.hpp
+++ b/etsi_its_conversion/etsi_its_conversion/include/etsi_its_conversion/Converter.hpp
@@ -197,7 +197,6 @@ class Converter : public rclcpp::Node {
     std::vector<std::string> udp2ros_etsi_types_;
     int subscriber_queue_size_;
     int publisher_queue_size_;
-    bool check_constraints_before_encoding_;
 
 #ifdef ROS1
     ros::NodeHandle private_node_handle_;

--- a/utils/codegen/asn1ToC/patches/vam_ts.patch
+++ b/utils/codegen/asn1ToC/patches/vam_ts.patch
@@ -1,0 +1,18 @@
+diff --git a/etsi_its_coding/etsi_its_vam_ts_coding/src/vam_ts_ItsPduHeaderVam.c b/etsi_its_coding/etsi_its_vam_ts_coding/src/vam_ts_ItsPduHeaderVam.c
+index 49c5a79a..06a665c0 100644
+--- a/etsi_its_coding/etsi_its_vam_ts_coding/src/vam_ts_ItsPduHeaderVam.c
++++ b/etsi_its_coding/etsi_its_vam_ts_coding/src/vam_ts_ItsPduHeaderVam.c
+@@ -23,7 +23,12 @@ vam_ts_ItsPduHeaderVam_constraint(const asn_TYPE_descriptor_t *td, const void *s
+ 		/* Nothing is here. See below */
+ 	}
+ 	
+-	return td->encoding_constraints.general_constraints(td, sptr, ctfailcb, app_key);
++	/* prevent infinite recursion */
++	if (td->encoding_constraints.general_constraints != vam_ts_ItsPduHeaderVam_constraint) {
++		return td->encoding_constraints.general_constraints(td, sptr, ctfailcb, app_key);
++	} else {
++		return 0;
++	}
+ }
+ 
+ /*


### PR DESCRIPTION
I assume that the `WITH COMPONENTS` constraints are not properly supported by asn1c yet.
Updating the asn1c version used in the codegen container did not help either. This patch is a desperate workaround until the constraints are properly checked.