### PR TITLE
Add setters and getters for yaw rate in CAM and CAM TS

### DIFF
--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
@@ -119,6 +119,14 @@ inline double getHeadingConfidence(const CAM& cam) {
   return getHeadingConfidenceCDD(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.heading);
 }
 
+inline double getYawRate(const CAM& cam) {
+  return getYawRateCDD(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.yaw_rate);
+}
+
+inline double getYawRateConfidence(const CAM& cam) {
+  return getYawRateConfidenceCDD(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.yaw_rate);
+}
+
 /**
  * @brief Get the Vehicle Length
  *

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_getters_common.h
@@ -119,10 +119,22 @@ inline double getHeadingConfidence(const CAM& cam) {
   return getHeadingConfidenceCDD(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.heading);
 }
 
+/**
+ * @brief Get the Yaw Rate of CAM
+ * 
+ * @param cam CAM to get the YawRate from
+ * @return double yaw rate in degrees per second as decimal number
+ */
 inline double getYawRate(const CAM& cam) {
   return getYawRateCDD(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.yaw_rate);
 }
 
+/**
+ * @brief Get the Yaw Rate Confidence of CAM
+ * 
+ * @param cam CAM to get the YawRateConfidence from
+ * @return double yaw rate standard deviation in degrees per second as decimal number
+ */
 inline double getYawRateConfidence(const CAM& cam) {
   return getYawRateConfidenceCDD(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.yaw_rate);
 }

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
@@ -91,6 +91,14 @@ inline void setHeading(CAM& cam, const double heading_val, const double confiden
              heading_val, confidence);
 }
 
+/**
+ * @brief Set the Yaw Rate for a CAM
+ *
+ * @param cam CAM to set the YawRate
+ * @param yaw_rate_val Yaw rate value in degrees per second as decimal number
+ * @param confidence standard deviation of yaw rate in degrees per second as decimal number (default: infinity, mapping to YawRateConfidence::UNAVAILABLE)
+ */
+
 inline void setYawRate(CAM& cam, const double yaw_rate_val,
                      const double confidence = std::numeric_limits<double>::infinity()) {
   setYawRateCDD(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.yaw_rate,

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cam/cam_setters_common.h
@@ -91,6 +91,12 @@ inline void setHeading(CAM& cam, const double heading_val, const double confiden
              heading_val, confidence);
 }
 
+inline void setYawRate(CAM& cam, const double yaw_rate_val,
+                     const double confidence = std::numeric_limits<double>::infinity()) {
+  setYawRateCDD(cam.cam.cam_parameters.high_frequency_container.basic_vehicle_container_high_frequency.yaw_rate,
+                yaw_rate_val, confidence);
+}
+
 /**
  * @brief Set the VehicleWidth object
  *

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
@@ -88,6 +88,28 @@ inline double getSpeedConfidence(const Speed& speed) {
 }
 
 /**
+ * @brief Get the AccelerationMagnitude value
+ * 
+ * @param acceleration_magnitude to get the AccelerationMagnitude from
+ * @return double acceleration magnitude in m/s^2 as decimal number
+ */
+template <typename AccelerationMagnitude>
+inline double getAccelerationMagnitude(const AccelerationMagnitude& acceleration_magnitude) {
+  return ((double)acceleration_magnitude.acceleration_magnitude_value.value) * 1e-1;
+}
+
+/**
+ * @brief Get the AccelerationMagnitude Confidence
+ * 
+ * @param acceleration_magnitude to get the AccelerationMagnitudeConfidence from
+ * @return double acceleration magnitude standard deviation in m/s^2 as decimal number
+ */
+template <typename AccelerationMagnitude>
+inline double getAccelerationMagnitudeConfidence(const AccelerationMagnitude& acceleration_magnitude) {
+  return ((double)acceleration_magnitude.acceleration_confidence.value) / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR * 1e-1;
+}
+
+/**
  * @brief Get the UTM Position defined by the given ReferencePosition
  *
  * The position is transformed into UTM by using GeographicLib::UTMUPS

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_getters_common.h
@@ -142,6 +142,41 @@ template <typename Heading>
 inline double getHeadingConfidenceCDD(const Heading& heading) { return ((double)heading.heading_confidence.value) * 1e-1 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR; }
 
 /**
+ * @brief Get the Yaw Rate value
+ * 
+ * @param yaw_rate The YawRate object to get the yaw rate from
+ * @return double The yaw rate in degrees per second
+ */
+template <typename YawRate>
+inline double getYawRateCDD(const YawRate& yaw_rate) {
+  return ((double)yaw_rate.yaw_rate_value.value) * 1e-2; // Yaw rate in deg/s
+}
+
+/**
+ * @brief Get the Yaw Rate Confidence
+ * 
+ * @param yaw_rate The YawRate object to get the yaw rate confidence from
+ * @return double The yaw rate standard deviation in degrees per second
+ */
+template <typename YawRate, typename YawRateConfidence = decltype(YawRate::yaw_rate_confidence)>
+inline double getYawRateConfidenceCDD(const YawRate& yaw_rate) {
+  auto val = yaw_rate.yaw_rate_confidence.value;
+  static const std::map<uint8_t, double> confidence_map = {
+      {YawRateConfidence::UNAVAILABLE, 0.0},
+      {YawRateConfidence::DEG_SEC_000_01, 0.01},
+      {YawRateConfidence::DEG_SEC_000_05, 0.05},
+      {YawRateConfidence::DEG_SEC_000_10, 0.1},
+      {YawRateConfidence::DEG_SEC_001_00, 1.0},
+      {YawRateConfidence::DEG_SEC_005_00, 5.0},
+      {YawRateConfidence::DEG_SEC_010_00, 10.0},
+      {YawRateConfidence::DEG_SEC_100_00, 100.0},
+      {YawRateConfidence::OUT_OF_RANGE, std::numeric_limits<double>::infinity()},
+  };
+  return confidence_map.at(val) / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR; 
+}
+
+
+/**
  * @brief Get the Semi Axis object
  * 
  * @param semi_axis_length The SemiAxisLength object to get the semi axis from

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
@@ -282,7 +282,7 @@ void setHeadingCDD(Heading& heading, const double value, double confidence = std
 template <typename YawRate, typename YawRateValue = decltype(YawRate::yaw_rate_value), typename YawRateConfidence = decltype(YawRate::yaw_rate_confidence)>
 inline void setYawRateCDD(YawRate& yaw_rate, const double value,
                                         double confidence = std::numeric_limits<double>::infinity()) {
-  double yaw_rate_in_001_degrees = value;
+  double yaw_rate_in_001_degrees = value * 100.0;
   // limit value range
   if (yaw_rate_in_001_degrees < YawRateValue::MIN) {
     yaw_rate_in_001_degrees = YawRateValue::MIN; // MIN should be NEGATIVE_OUT_OF_RANGE, but CAM only has MIN
@@ -299,13 +299,13 @@ inline void setYawRateCDD(YawRate& yaw_rate, const double value,
     yaw_rate_std *= etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR; 
     // How stupid is this?!
     static const std::map<double, uint8_t> confidence_map = {
-        {YawRateConfidence::DEG_SEC_000_01, 0.01},
-        {YawRateConfidence::DEG_SEC_000_05, 0.05},
-        {YawRateConfidence::DEG_SEC_000_10, 0.1},
-        {YawRateConfidence::DEG_SEC_001_00, 1.0},
-        {YawRateConfidence::DEG_SEC_005_00, 5.0},
-        {YawRateConfidence::DEG_SEC_010_00, 10.0},
-        {YawRateConfidence::DEG_SEC_100_00, 100.0},
+        {0.01, YawRateConfidence::DEG_SEC_000_01},
+        {0.05, YawRateConfidence::DEG_SEC_000_05},
+        {0.1, YawRateConfidence::DEG_SEC_000_10},
+        {1.0, YawRateConfidence::DEG_SEC_001_00},
+        {5.0, YawRateConfidence::DEG_SEC_005_00},
+        {10.0, YawRateConfidence::DEG_SEC_010_00},
+        {100.0, YawRateConfidence::DEG_SEC_100_00},
         {std::numeric_limits<double>::infinity(), YawRateConfidence::OUT_OF_RANGE},
     };
     for(const auto& [thresh, conf_val] : confidence_map) {

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cdd/cdd_setters_common.h
@@ -154,6 +154,52 @@ inline void setSpeed(Speed& speed, const double value, const double confidence =
 }
 
 /**
+ * @brief Set the Acceleration Magnitude Value object
+ * 
+ * @param accel_mag_value object to set
+ * @param value AccelerationMagnitudeValue in m/s^2 as decimal number
+ */
+template <typename AccelerationMagnitudeValue>
+inline void setAccelerationMagnitudeValue(AccelerationMagnitudeValue& accel_mag_value, const double value) {
+  auto accel_mag = std::round(value * 1e1);
+  throwIfOutOfRange(accel_mag, AccelerationMagnitudeValue::MIN, AccelerationMagnitudeValue::MAX, "AccelerationMagnitudeValue");
+  accel_mag_value.value = static_cast<decltype(accel_mag_value.value)>(accel_mag);
+}
+
+/**
+ * @brief Set the AccelerationMagnitude Confidence object
+ * 
+ * @param accel_mag_confidence object to set
+ * @param value standard deviation in m/s^2 as decimal number
+ */
+template <typename AccelerationConfidence>
+inline void setAccelerationMagnitudeConfidence(AccelerationConfidence& accel_mag_confidence, const double value) {
+  auto accel_mag_conf = std::round(value * 1e1 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+  if (accel_mag_conf < AccelerationConfidence::MIN && accel_mag_conf > 0.0){
+    accel_mag_conf = AccelerationConfidence::MIN;
+  } else if (accel_mag_conf >= AccelerationConfidence::OUT_OF_RANGE || accel_mag_conf <= 0.0) {
+    accel_mag_conf = AccelerationConfidence::UNAVAILABLE;
+  }
+  accel_mag_confidence.value = static_cast<decltype(accel_mag_confidence.value)>(accel_mag_conf);
+}
+
+/**
+ * @brief Set the AccelerationMagnitude object
+ *
+ * AccelerationConfidence is set to UNAVAILABLE
+ *
+ * @param accel_mag object to set
+ * @param value AccelerationMagnitudeValue in m/s^2 as decimal number
+ * @param confidence standard deviation in m/s^2 as decimal number (default: infinity, mapping to AccelerationConfidence::UNAVAILABLE)
+ */
+template<typename AccelerationMagnitude>
+inline void setAccelerationMagnitude(AccelerationMagnitude& accel_mag, const double value,
+                                     const double confidence = std::numeric_limits<double>::infinity()) {
+  setAccelerationMagnitudeConfidence(accel_mag.acceleration_confidence, confidence);
+  setAccelerationMagnitudeValue(accel_mag.acceleration_magnitude_value, value);
+}
+
+/**
  * @brief Set the Acceleration Confidence object
  * 
  * @param accel_confidence object to set

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
@@ -428,15 +428,27 @@ inline double getVelocityComponentConfidence(const VelocityComponent &velocity) 
  * @throws std::invalid_argument If the velocity is no cartesian velocity.
  */
 inline gm::Vector3 getCartesianVelocityOfPerceivedObject(const PerceivedObject &object) {
-  if (!object.velocity_is_present) throw std::invalid_argument("No velocity present in PerceivedObject");
-  if (object.velocity.choice != Velocity3dWithConfidence::CHOICE_CARTESIAN_VELOCITY) {
-    throw std::invalid_argument("Velocity is not Cartesian");
+  if (!object.velocity_is_present) {
+    throw std::invalid_argument("No velocity present in PerceivedObject");
   }
   gm::Vector3 velocity;
-  velocity.x = getVelocityComponent(object.velocity.cartesian_velocity.x_velocity);
-  velocity.y = getVelocityComponent(object.velocity.cartesian_velocity.y_velocity);
-  if (object.velocity.cartesian_velocity.z_velocity_is_present) {
-    velocity.z = getVelocityComponent(object.velocity.cartesian_velocity.z_velocity);
+  if (object.velocity.choice == Velocity3dWithConfidence::CHOICE_POLAR_VELOCITY) {
+    double speed = getSpeed(object.velocity.polar_velocity.velocity_magnitude);
+    double angle = getCartesianAngle(object.velocity.polar_velocity.velocity_direction) * M_PI / 180.0 / 10.0; // convert to radians
+    velocity.x = speed * cos(angle);
+    velocity.y = speed * sin(angle);
+    if (object.velocity.polar_velocity.z_velocity_is_present) {
+      velocity.z = getVelocityComponent(object.velocity.cartesian_velocity.z_velocity);
+    }
+  } else if (object.velocity.choice == Velocity3dWithConfidence::CHOICE_CARTESIAN_VELOCITY) {
+    gm::Vector3 velocity;
+    velocity.x = getVelocityComponent(object.velocity.cartesian_velocity.x_velocity);
+    velocity.y = getVelocityComponent(object.velocity.cartesian_velocity.y_velocity);
+    if (object.velocity.cartesian_velocity.z_velocity_is_present) {
+      velocity.z = getVelocityComponent(object.velocity.cartesian_velocity.z_velocity);
+    }
+  } else {
+    throw std::invalid_argument("Velocity is neither Polar nor Cartesian");
   }
   return velocity;
 }
@@ -450,16 +462,34 @@ inline gm::Vector3 getCartesianVelocityOfPerceivedObject(const PerceivedObject &
  * @throws std::invalid_argument If the velocity is no cartesian velocity.
  */
 inline std::tuple<double, double, double> getCartesianVelocityConfidenceOfPerceivedObject(const PerceivedObject &object) {
-  if (!object.velocity_is_present) throw std::invalid_argument("No velocity present in PerceivedObject");
-  if (object.velocity.choice != Velocity3dWithConfidence::CHOICE_CARTESIAN_VELOCITY) {
-    throw std::invalid_argument("Velocity is not Cartesian");
+  if (!object.velocity_is_present) {
+    throw std::invalid_argument("No velocity present in PerceivedObject");
   }
-  double x_confidence = getVelocityComponentConfidence(object.velocity.cartesian_velocity.x_velocity);
-  double y_confidence = getVelocityComponentConfidence(object.velocity.cartesian_velocity.y_velocity);
-  double z_confidence = object.velocity.cartesian_velocity.z_velocity_is_present
-                            ? getVelocityComponentConfidence(object.velocity.cartesian_velocity.z_velocity)
-                            : std::numeric_limits<double>::infinity();
-  return std::make_tuple(x_confidence, y_confidence, z_confidence);
+  if (object.velocity.choice == Velocity3dWithConfidence::CHOICE_POLAR_VELOCITY) {
+    double speed_confidence = getSpeedConfidence(object.velocity.polar_velocity.velocity_magnitude);
+    double angle_confidence = getCartesianAngleConfidence(object.velocity.polar_velocity.velocity_direction) * M_PI / 180.0 / 10.0; // convert to radians
+    double angle = getCartesianAngle(object.velocity.polar_velocity.velocity_direction) * M_PI / 180.0 / 10.0; // convert to radians
+    double lateral_confidence = speed_confidence * angle_confidence; // not exactly, but best approximation
+    double x_confidence = speed_confidence * cos(angle) * cos(angle) 
+                          + lateral_confidence * sin(angle) * sin(angle);
+    double y_confidence = speed_confidence * sin(angle) * sin(angle)
+                          + lateral_confidence * cos(angle) * cos(angle);
+    // neglect xy covariance, as it is not present in the output of this function
+    double z_confidence = object.velocity.polar_velocity.z_velocity_is_present
+                              ? getVelocityComponentConfidence(object.velocity.cartesian_velocity.z_velocity)
+                              : std::numeric_limits<double>::infinity();
+    return std::make_tuple(x_confidence, y_confidence, z_confidence);
+  } else if (object.velocity.choice == Velocity3dWithConfidence::CHOICE_CARTESIAN_VELOCITY) {
+    double x_confidence = getVelocityComponentConfidence(object.velocity.cartesian_velocity.x_velocity);
+    double y_confidence = getVelocityComponentConfidence(object.velocity.cartesian_velocity.y_velocity);
+    double z_confidence = object.velocity.cartesian_velocity.z_velocity_is_present
+                              ? getVelocityComponentConfidence(object.velocity.cartesian_velocity.z_velocity)
+                              : std::numeric_limits<double>::infinity();
+    return std::make_tuple(x_confidence, y_confidence, z_confidence);
+  } else {
+    throw std::invalid_argument("Velocity is neither Polar nor Cartesian");
+  }
+  
 }
 
 /**
@@ -490,16 +520,29 @@ inline double getAccelerationComponentConfidence(const AccelerationComponent &ac
  * @throws std::invalid_argument If the acceleration is no cartesian acceleration.
  */
 inline gm::Vector3 getCartesianAccelerationOfPerceivedObject(const PerceivedObject &object) {
-  if (!object.acceleration_is_present) throw std::invalid_argument("No acceleration present in PerceivedObject");
-  if (object.acceleration.choice != Acceleration3dWithConfidence::CHOICE_CARTESIAN_ACCELERATION) {
-    throw std::invalid_argument("Acceleration is not Cartesian");
+  if (!object.acceleration_is_present) {
+    throw std::invalid_argument("No acceleration present in PerceivedObject");
   }
   gm::Vector3 acceleration;
-  acceleration.x = getAccelerationComponent(object.acceleration.cartesian_acceleration.x_acceleration);
-  acceleration.y = getAccelerationComponent(object.acceleration.cartesian_acceleration.y_acceleration);
-  if (object.acceleration.cartesian_acceleration.z_acceleration_is_present) {
-    acceleration.z = getAccelerationComponent(object.acceleration.cartesian_acceleration.z_acceleration);
+
+  if (object.acceleration.choice == Acceleration3dWithConfidence::CHOICE_CARTESIAN_ACCELERATION) {
+    acceleration.x = getAccelerationComponent(object.acceleration.cartesian_acceleration.x_acceleration);
+    acceleration.y = getAccelerationComponent(object.acceleration.cartesian_acceleration.y_acceleration);
+    if (object.acceleration.cartesian_acceleration.z_acceleration_is_present) {
+      acceleration.z = getAccelerationComponent(object.acceleration.cartesian_acceleration.z_acceleration);
+    }
+  } else if (object.acceleration.choice == Acceleration3dWithConfidence::CHOICE_POLAR_ACCELERATION) {
+    double magnitude = getAccelerationMagnitude(object.acceleration.polar_acceleration.acceleration_magnitude);
+    double angle = getCartesianAngle(object.acceleration.polar_acceleration.acceleration_direction) * M_PI / 180.0 / 10.0; // convert to radians
+    acceleration.x = magnitude * cos(angle);
+    acceleration.y = magnitude * sin(angle);
+    if (object.acceleration.polar_acceleration.z_acceleration_is_present) {
+      acceleration.z = getAccelerationComponent(object.acceleration.polar_acceleration.z_acceleration);
+    }
+  } else {
+    throw std::invalid_argument("Acceleration is neither Cartesian nor Polar");
   }
+
   return acceleration;
 }
 
@@ -513,15 +556,31 @@ inline gm::Vector3 getCartesianAccelerationOfPerceivedObject(const PerceivedObje
  */
 inline std::tuple<double, double, double> getCartesianAccelerationConfidenceOfPerceivedObject(const PerceivedObject &object) {
   if (!object.acceleration_is_present) throw std::invalid_argument("No acceleration present in PerceivedObject");
-  if (object.acceleration.choice != Acceleration3dWithConfidence::CHOICE_CARTESIAN_ACCELERATION) {
-    throw std::invalid_argument("Acceleration is not Cartesian");
+
+  if (object.acceleration.choice == Acceleration3dWithConfidence::CHOICE_CARTESIAN_ACCELERATION) {
+    double x_confidence = getAccelerationComponentConfidence(object.acceleration.cartesian_acceleration.x_acceleration);
+    double y_confidence = getAccelerationComponentConfidence(object.acceleration.cartesian_acceleration.y_acceleration);
+    double z_confidence = object.acceleration.cartesian_acceleration.z_acceleration_is_present
+                              ? getAccelerationComponentConfidence(object.acceleration.cartesian_acceleration.z_acceleration)
+                              : std::numeric_limits<double>::infinity();
+    return std::make_tuple(x_confidence, y_confidence, z_confidence);
+  } else if (object.acceleration.choice == Acceleration3dWithConfidence::CHOICE_POLAR_ACCELERATION) {
+    double magnitude_confidence = getAccelerationMagnitudeConfidence(object.acceleration.polar_acceleration.acceleration_magnitude);
+    double angle_confidence = getCartesianAngleConfidence(object.acceleration.polar_acceleration.acceleration_direction) * M_PI / 180.0 / 10.0; // convert to radians
+    double angle = getCartesianAngle(object.acceleration.polar_acceleration.acceleration_direction) * M_PI / 180.0 / 10.0; // convert to radians
+    double lateral_confidence = magnitude_confidence * angle_confidence; // best approximation
+    double x_confidence = magnitude_confidence * cos(angle) * cos(angle)
+                          + lateral_confidence * sin(angle) * sin(angle);
+    double y_confidence = magnitude_confidence * sin(angle) * sin(angle)
+                          + lateral_confidence * cos(angle) * cos(angle);
+    // neglect xy covariance, as it is not present in the output of this function
+    double z_confidence = object.acceleration.polar_acceleration.z_acceleration_is_present
+                              ? getAccelerationComponentConfidence(object.acceleration.polar_acceleration.z_acceleration)
+                              : std::numeric_limits<double>::infinity();
+    return std::make_tuple(x_confidence, y_confidence, z_confidence);
+  } else {
+    throw std::invalid_argument("Acceleration is neither Cartesian nor Polar");
   }
-  double x_confidence = getAccelerationComponentConfidence(object.acceleration.cartesian_acceleration.x_acceleration);
-  double y_confidence = getAccelerationComponentConfidence(object.acceleration.cartesian_acceleration.y_acceleration);
-  double z_confidence = object.acceleration.cartesian_acceleration.z_acceleration_is_present
-                            ? getAccelerationComponentConfidence(object.acceleration.cartesian_acceleration.z_acceleration)
-                            : std::numeric_limits<double>::infinity();
-  return std::make_tuple(x_confidence, y_confidence, z_confidence);
 }
 
 /**

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_getters.h
@@ -441,7 +441,6 @@ inline gm::Vector3 getCartesianVelocityOfPerceivedObject(const PerceivedObject &
       velocity.z = getVelocityComponent(object.velocity.cartesian_velocity.z_velocity);
     }
   } else if (object.velocity.choice == Velocity3dWithConfidence::CHOICE_CARTESIAN_VELOCITY) {
-    gm::Vector3 velocity;
     velocity.x = getVelocityComponent(object.velocity.cartesian_velocity.x_velocity);
     velocity.y = getVelocityComponent(object.velocity.cartesian_velocity.y_velocity);
     if (object.velocity.cartesian_velocity.z_velocity_is_present) {
@@ -466,10 +465,11 @@ inline std::tuple<double, double, double> getCartesianVelocityConfidenceOfPercei
     throw std::invalid_argument("No velocity present in PerceivedObject");
   }
   if (object.velocity.choice == Velocity3dWithConfidence::CHOICE_POLAR_VELOCITY) {
-    double speed_confidence = getSpeedConfidence(object.velocity.polar_velocity.velocity_magnitude);
-    double angle_confidence = getCartesianAngleConfidence(object.velocity.polar_velocity.velocity_direction) * M_PI / 180.0 / 10.0; // convert to radians
+    double speed_confidence = getSpeedConfidence(object.velocity.polar_velocity.velocity_magnitude) / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR;
+    double angle_confidence = getCartesianAngleConfidence(object.velocity.polar_velocity.velocity_direction) * M_PI / 180.0 / 10.0 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR; // convert to radians
+    double speed = getSpeed(object.velocity.polar_velocity.velocity_magnitude);
     double angle = getCartesianAngle(object.velocity.polar_velocity.velocity_direction) * M_PI / 180.0 / 10.0; // convert to radians
-    double lateral_confidence = speed_confidence * angle_confidence; // not exactly, but best approximation
+    double lateral_confidence = speed * angle_confidence; // not exactly, but best approximation
     double x_confidence = speed_confidence * cos(angle) * cos(angle) 
                           + lateral_confidence * sin(angle) * sin(angle);
     double y_confidence = speed_confidence * sin(angle) * sin(angle)
@@ -566,9 +566,10 @@ inline std::tuple<double, double, double> getCartesianAccelerationConfidenceOfPe
     return std::make_tuple(x_confidence, y_confidence, z_confidence);
   } else if (object.acceleration.choice == Acceleration3dWithConfidence::CHOICE_POLAR_ACCELERATION) {
     double magnitude_confidence = getAccelerationMagnitudeConfidence(object.acceleration.polar_acceleration.acceleration_magnitude);
-    double angle_confidence = getCartesianAngleConfidence(object.acceleration.polar_acceleration.acceleration_direction) * M_PI / 180.0 / 10.0; // convert to radians
+    double angle_confidence = getCartesianAngleConfidence(object.acceleration.polar_acceleration.acceleration_direction) * M_PI / 180.0 / 10.0 / etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR; // convert to radians
+    double magnitude = getAccelerationMagnitude(object.acceleration.polar_acceleration.acceleration_magnitude);
     double angle = getCartesianAngle(object.acceleration.polar_acceleration.acceleration_direction) * M_PI / 180.0 / 10.0; // convert to radians
-    double lateral_confidence = magnitude_confidence * angle_confidence; // best approximation
+    double lateral_confidence = magnitude * angle_confidence; // best approximation
     double x_confidence = magnitude_confidence * cos(angle) * cos(angle)
                           + lateral_confidence * sin(angle) * sin(angle);
     double y_confidence = magnitude_confidence * sin(angle) * sin(angle)

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
@@ -275,7 +275,7 @@ inline void setCartesianAngle(CartesianAngle& angle, const double value,
   // wrap angle to 0..2pi
   double wrapped_value = fmod(value, 2*M_PI);
   if (wrapped_value < 0.0) {
-    wrapped_value += 2*M_PI;
+    wrapped_value += 2 * M_PI;
   }
   angle.value.value = static_cast<uint16_t>(wrapped_value * 180 / M_PI * 10); // convert to 0.1 degrees
 
@@ -411,6 +411,17 @@ inline void setAccelerationOfPerceivedObject(PerceivedObject& object, const gm::
   object.acceleration_is_present = true;
 }
 
+/**
+ * @brief Set the Polar Acceleration Of Perceived Object object
+ * 
+ * @param object PerceivedObject to set the Polar Acceleration for
+ * @param magnitude The magnitude of the acceleration in m/s^2 in the xy plane.
+ * @param angle The angle of the acceleration in radians in the xy plane.
+ * @param z The z component of the acceleration in m/s^2 (default: 0.0).
+ * @param magnitude_std The standard deviation in m/s^2 for the acceleration magnitude (default: infinity).
+ * @param angle_std The standard deviation in radians for the angle (default: infinity).
+ * @param z_std The standard deviation in m/s^2 for the z acceleration component (default: infinity).
+ */
 inline void setPolarAccelerationOfPerceivedObject(PerceivedObject& object,
                                               const double magnitude,
                                               const double angle,
@@ -422,7 +433,7 @@ inline void setPolarAccelerationOfPerceivedObject(PerceivedObject& object,
   setAccelerationMagnitude(object.acceleration.polar_acceleration.acceleration_magnitude, magnitude, magnitude_std);
   setCartesianAngle(object.acceleration.polar_acceleration.acceleration_direction, angle, angle_std);
   if (z != 0.0) {
-    setAccelerationComponent(object.acceleration.cartesian_acceleration.z_acceleration, z * 10,
+    setAccelerationComponent(object.acceleration.polar_acceleration.z_acceleration, z * 10,
                              z_std * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
     object.acceleration.polar_acceleration.z_acceleration_is_present = true;
   } else {

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/cpm/cpm_ts_setters.h
@@ -264,6 +264,33 @@ inline void setVelocityComponent(VelocityComponent& velocity, const double value
 }
 
 /**
+ * @brief Set a Cartesian Angle
+ * 
+ * @param angle The CartesianAngle object to be set.
+ * @param value Angle in radians to be set in the CartesianAngle object.
+ * @param confidence standard deviation of the angle in radians (default: infinity, which will map to AngleConfidence::UNAVAILABLE).
+ */
+inline void setCartesianAngle(CartesianAngle& angle, const double value,
+                              double confidence = std::numeric_limits<double>::infinity()) {
+  // wrap angle to 0..2pi
+  double wrapped_value = fmod(value, 2*M_PI);
+  if (wrapped_value < 0.0) {
+    wrapped_value += 2*M_PI;
+  }
+  angle.value.value = static_cast<uint16_t>(wrapped_value * 180 / M_PI * 10); // convert to 0.1 degrees
+
+  confidence *= 180.0 / M_PI * 10.0 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR; // convert to 0.1 degrees
+  // limit confidence range
+  if(confidence == std::numeric_limits<double>::infinity() || confidence <= 0.0) {
+    angle.confidence.value = AngleConfidence::UNAVAILABLE;
+  } else if (confidence > AngleConfidence::MAX || confidence < AngleConfidence::MIN) {
+    angle.confidence.value = AngleConfidence::OUT_OF_RANGE;
+  } else {
+    angle.confidence.value = static_cast<uint8_t>(confidence);
+  }
+}
+
+/**
  * Sets the velocity of a perceived object.
  *
  * This function sets the velocity of a perceived object using the provided Cartesian velocity components.
@@ -285,8 +312,42 @@ inline void setVelocityOfPerceivedObject(PerceivedObject& object, const gm::Vect
   if (cartesian_velocity.z != 0.0) {
     setVelocityComponent(object.velocity.cartesian_velocity.z_velocity, cartesian_velocity.z * 100, z_std * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
     object.velocity.cartesian_velocity.z_velocity_is_present = true;
+  } else {
+    object.velocity.cartesian_velocity.z_velocity_is_present = false;
   }
   object.velocity_is_present = true;
+}
+
+/**
+ * Sets the velocity of a perceived object.
+ *
+ * This function sets the velocity of a perceived object using the provided Polar velocity components.
+ * Optionally, confidence values can be specified for each velocity component.
+ *
+ * @param object The perceived object for which the velocity is being set.
+ * @param magnitude The magnitude of the velocity in m/s in the xy plane.
+ * @param angle The angle of the velocity in radians in the xy plane.
+ * @param z The z component of the velocity in m/s (default: 0.0).
+ * @param magnitude_std The standard deviation in m/s for the velocity magnitude (default: infinity).
+ * @param angle_std The standard deviation in radians for the angle (default: infinity).
+ * @param z_std The standard deviation in m/s for the z velocity component (default: infinity).
+ */
+inline void setPolarVelocityOfPerceivedObject(PerceivedObject& object,
+                                              const double magnitude,
+                                              const double angle,
+                                              const double z = 0.0,
+                                              const double magnitude_std = std::numeric_limits<double>::infinity(),
+                                              const double angle_std = std::numeric_limits<double>::infinity(),
+                                              const double z_std = std::numeric_limits<double>::infinity()) {
+  object.velocity.choice = Velocity3dWithConfidence::CHOICE_POLAR_VELOCITY;
+  setSpeed(object.velocity.polar_velocity.velocity_magnitude, magnitude, magnitude_std);
+  setCartesianAngle(object.velocity.polar_velocity.velocity_direction, angle, angle_std);
+  if (z != 0.0) {
+    setVelocityComponent(object.velocity.cartesian_velocity.z_velocity, z * 100, z_std * 100 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+    object.velocity.polar_velocity.z_velocity_is_present = true;
+  } else {
+    object.velocity.polar_velocity.z_velocity_is_present = false;
+  }
 }
 
 /**
@@ -346,6 +407,26 @@ inline void setAccelerationOfPerceivedObject(PerceivedObject& object, const gm::
     setAccelerationComponent(object.acceleration.cartesian_acceleration.z_acceleration, cartesian_acceleration.z * 10,
                              z_std * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
     object.acceleration.cartesian_acceleration.z_acceleration_is_present = true;
+  }
+  object.acceleration_is_present = true;
+}
+
+inline void setPolarAccelerationOfPerceivedObject(PerceivedObject& object,
+                                              const double magnitude,
+                                              const double angle,
+                                              const double z = 0.0,
+                                              const double magnitude_std = std::numeric_limits<double>::infinity(),
+                                              const double angle_std = std::numeric_limits<double>::infinity(),
+                                              const double z_std = std::numeric_limits<double>::infinity()) {
+  object.acceleration.choice = Acceleration3dWithConfidence::CHOICE_POLAR_ACCELERATION;
+  setAccelerationMagnitude(object.acceleration.polar_acceleration.acceleration_magnitude, magnitude, magnitude_std);
+  setCartesianAngle(object.acceleration.polar_acceleration.acceleration_direction, angle, angle_std);
+  if (z != 0.0) {
+    setAccelerationComponent(object.acceleration.cartesian_acceleration.z_acceleration, z * 10,
+                             z_std * 10 * etsi_its_msgs::ONE_D_GAUSSIAN_FACTOR);
+    object.acceleration.polar_acceleration.z_acceleration_is_present = true;
+  } else {
+    object.acceleration.polar_acceleration.z_acceleration_is_present = false;
   }
   object.acceleration_is_present = true;
 }

--- a/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
@@ -79,6 +79,17 @@ TEST(etsi_its_cam_msgs, test_set_get_cam) {
   EXPECT_NEAR(heading_val, cam_access::getHeading(cam), 1e-1);
   EXPECT_NEAR(heading_conf, cam_access::getHeadingConfidence(cam), 1e-1);
 
+  double yaw_rate = randomDouble(-327.65, 327.65);
+  double yaw_rate_conf = randomDouble(0.0, 49.5);
+  std::cerr << "yaw_rate: " << yaw_rate << ", yaw_rate_conf: " << yaw_rate_conf << std::endl;
+  cam_access::setYawRate(cam, yaw_rate, yaw_rate_conf);
+  EXPECT_NEAR(yaw_rate, cam_access::getYawRate(cam), 1e-2);
+  std::array<double, 7> yaw_std_possible_values{0.01, 0.05, 0.1, 1.0, 5.0, 10.0, 100.0};
+  std::for_each(yaw_std_possible_values.begin(), yaw_std_possible_values.end(),
+                [](double& val) { val *= 0.5; });
+  double expected_yaw_rate = *std::lower_bound(yaw_std_possible_values.begin(), yaw_std_possible_values.end(), yaw_rate_conf);
+  EXPECT_NEAR(expected_yaw_rate, cam_access::getYawRateConfidence(cam), 1e-2);
+
   std::array<double, 4> covariance_matrix = {randomDouble(1.0, 100.0), 0.0,
     0.0, randomDouble(1.0, 100.0)};
   // Make y component larger than x component so the ellipse will have its major axis 90° rotated

--- a/etsi_its_msgs_utils/test/impl/test_cam_ts_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cam_ts_access.cpp
@@ -79,6 +79,17 @@ TEST(etsi_its_cam_ts_msgs, test_set_get_cam) {
   EXPECT_NEAR(heading_val, cam_ts_access::getHeading(cam), 1e-1);
   EXPECT_NEAR(heading_conf, cam_ts_access::getHeadingConfidence(cam), 1e-1);
 
+  double yaw_rate = randomDouble(-327.65, 327.65);
+  double yaw_rate_conf = randomDouble(0.0, 49.5);
+  std::cerr << "yaw_rate: " << yaw_rate << ", yaw_rate_conf: " << yaw_rate_conf << std::endl;
+  cam_ts_access::setYawRate(cam, yaw_rate, yaw_rate_conf);
+  EXPECT_NEAR(yaw_rate, cam_ts_access::getYawRate(cam), 1e-2);
+  std::array<double, 7> yaw_std_possible_values{0.01, 0.05, 0.1, 1.0, 5.0, 10.0, 100.0};
+  std::for_each(yaw_std_possible_values.begin(), yaw_std_possible_values.end(),
+                [](double& val) { val *= 0.5; });
+  double expected_yaw_rate = *std::lower_bound(yaw_std_possible_values.begin(), yaw_std_possible_values.end(), yaw_rate_conf);
+  EXPECT_NEAR(expected_yaw_rate, cam_ts_access::getYawRateConfidence(cam), 1e-2);
+
   std::array<double, 4> covariance_matrix = {randomDouble(1.0, 100.0), 0.0,
     0.0, randomDouble(1.0, 100.0)};
   // Make y component larger than x component so the ellipse will have its major axis 90° rotated

--- a/etsi_its_msgs_utils/test/impl/test_cpm_ts_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cpm_ts_access.cpp
@@ -156,6 +156,28 @@ TEST(etsi_its_cpm_ts_msgs, test_set_get_cpm) {
   EXPECT_NEAR(velocity_y_std, vel_y_std_get, 1e-2);
   EXPECT_NEAR(velocity_z_std, vel_z_std_get, 1e-2);
 
+  // Polar velocity
+  double speed = randomDouble(0.1, 163.8);
+  double angle = randomDouble(0, 2.0 * M_PI);
+  double speed_std = randomDouble(0.01, 0.625);
+  double angle_std = randomDouble(0.001, 0.109);
+  cpm_ts_access::setPolarVelocityOfPerceivedObject(object, speed, angle, velocity.z, speed_std, angle_std, velocity_z_std);
+  double vel_x_expected = speed * cos(angle);
+  double vel_y_expected = speed * sin(angle);
+  auto vel_cart = cpm_ts_access::getCartesianVelocityOfPerceivedObject(object);
+  EXPECT_NEAR(vel_x_expected, vel_cart.x, 1e-1);
+  EXPECT_NEAR(vel_y_expected, vel_cart.y, 1e-1);
+  EXPECT_NEAR(velocity.z, vel_cart.z, 1e-1);
+
+  double vel_x_std_expected = speed_std * cos(angle) * cos(angle) +
+                          angle_std * speed * sin(angle) * sin(angle);
+  double vel_y_std_expected = speed_std * sin(angle) * sin(angle) +
+                          angle_std * speed * cos(angle) * cos(angle);
+  auto [vel_x_std, vel_y_std, vel_z_std] = cpm_ts_access::getCartesianVelocityConfidenceOfPerceivedObject(object);
+  EXPECT_NEAR(vel_x_std_expected, vel_x_std, 1e-1);
+  EXPECT_NEAR(vel_y_std_expected, vel_y_std, 1e-1);
+  EXPECT_NEAR(velocity_z_std, vel_z_std, 1e-1);
+
   // Acceleration
   gm::Vector3 acceleration;
   acceleration.x = randomDouble(-16.0, 16.0);
@@ -172,6 +194,27 @@ TEST(etsi_its_cpm_ts_msgs, test_set_get_cpm) {
   EXPECT_NEAR(acceleration_x_std, acc_x_std_get, 1e-1);
   EXPECT_NEAR(acceleration_y_std, acc_y_std_get, 1e-1);
   EXPECT_NEAR(acceleration_z_std, acc_z_std_get, 1e-1);
+
+  // Polar acceleration
+  double acc_magnitude = randomDouble(0.1, 16.0);
+  double acc_angle = randomDouble(0, 2.0 * M_PI);
+  double acc_magnitude_std = randomDouble(0.1, 5.0);
+  double acc_angle_std = randomDouble(0.001, 0.109);
+  cpm_ts_access::setPolarAccelerationOfPerceivedObject(object, acc_magnitude, acc_angle, acceleration.z, acc_magnitude_std, acc_angle_std, acceleration_z_std);
+  double acc_x_expected = acc_magnitude * cos(acc_angle);
+  double acc_y_expected = acc_magnitude * sin(acc_angle);
+  auto acc_cart = cpm_ts_access::getCartesianAccelerationOfPerceivedObject(object);
+  EXPECT_NEAR(acc_x_expected, acc_cart.x, 1e-1);
+  EXPECT_NEAR(acc_y_expected, acc_cart.y, 1e-1);
+  EXPECT_NEAR(acceleration.z, acc_cart.z, 1e-1);
+  double acc_x_std_expected = acc_magnitude_std * cos(acc_angle) * cos(acc_angle) +
+                          acc_angle_std * acc_magnitude * sin(acc_angle) * sin(acc_angle);
+  double acc_y_std_expected = acc_magnitude_std * sin(acc_angle) * sin(acc_angle) +
+                          acc_angle_std * acc_magnitude * cos(acc_angle) * cos(acc_angle);
+  auto [acc_x_std, acc_y_std, acc_z_std] = cpm_ts_access::getCartesianAccelerationConfidenceOfPerceivedObject(object);
+  EXPECT_NEAR(acc_x_std_expected, acc_x_std, 1e-1);
+  EXPECT_NEAR(acc_y_std_expected, acc_y_std, 1e-1);
+  EXPECT_NEAR(acceleration_z_std, acc_z_std, 1e-1);
 
   // SensorInformation
   cpm_ts_msgs::WrappedCpmContainer sensor_information_container;


### PR DESCRIPTION
- Adds all functions needed to conveniently interact with yaw rates and their standard deviation in CAMs
- Allows getters to interpret polar velocity and acceleration for PerceivedObjects in CPMs, and adds setters to set these polar values