### PR TITLE
Fix/missing inline on functions

### DIFF
--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
@@ -254,7 +254,7 @@ inline time_mark_value_interpretation interpretTimeMarkValueType(const uint16_t 
   */
 inline float interpretTimeMarkValueAsSeconds(const uint16_t time, const int32_t seconds, const uint32_t nanosec) {
   // calculate elapsed seconds since the start of the last full hour  
-  float abs_time_hour = ((int)(seconds)) % 3600 + (float)nanosec * 1e-9;
+  float abs_time_hour = ((int)(seconds)) % HOUR_IN_SECONDS + (float)nanosec * 1e-9;
   float rel_time_until_change = (float)time * 0.1f - abs_time_hour;
 
   // adjust relative time if a jump to the next hour occurs (relative time inside the interval [-30:00, 30:00] )

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
@@ -37,10 +37,11 @@ namespace etsi_its_spatem_ts_msgs {
 
 namespace access {
 
-  const std::array<float, 4> color_grey {0.5, 0.5, 0.5, 1.0};
-  const std::array<float, 4> color_green {0.18, 0.79, 0.21, 1.0};
-  const std::array<float, 4> color_orange {0.9, 0.7, 0.09, 1.0};
-  const std::array<float, 4> color_red {0.8, 0.2, 0.2, 1.0};
+  static constexpr  std::array<float, 4> COLOR_GREY {0.5, 0.5, 0.5, 1.0};
+  static constexpr  std::array<float, 4> COLOR_GREEN {0.18, 0.79, 0.21, 1.0};
+  static constexpr  std::array<float, 4> COLOR_ORANGE {0.9, 0.7, 0.09, 1.0};
+  static constexpr  std::array<float, 4> COLOR_RED {0.8, 0.2, 0.2, 1.0};
+
   static constexpr int HOUR_IN_SECONDS = 3600;
   static constexpr int HALF_HOUR_IN_SECONDS = 1800;
   static constexpr int64_t FACTOR_SECONDS_TO_NANOSECONDS = 1000000000LL; 
@@ -160,38 +161,38 @@ namespace access {
     switch (value) {
 
       case MovementPhaseState::UNAVAILABLE:
-        color = color_grey;
+        color = COLOR_GREY;
         break;
 
       case MovementPhaseState::DARK:
-        color = color_grey;
+        color = COLOR_GREY;
         break;
       case MovementPhaseState::STOP_THEN_PROCEED:
-        color = color_red;
+        color = COLOR_RED;
         break;
       case MovementPhaseState::STOP_AND_REMAIN:
-        color = color_red;
+        color = COLOR_RED;
         break;
       case MovementPhaseState::PRE_MOVEMENT:
-        color = color_orange;
+        color = COLOR_ORANGE;
         break;
       case MovementPhaseState::PERMISSIVE_MOVEMENT_ALLOWED:
-        color = color_green;
+        color = COLOR_GREEN;
         break;
       case MovementPhaseState::PROTECTED_MOVEMENT_ALLOWED:
-        color = color_green;
+        color = COLOR_GREEN;
         break;
       case MovementPhaseState::PERMISSIVE_CLEARANCE:
-        color = color_orange;
+        color = COLOR_ORANGE;
         break;
       case MovementPhaseState::PROTECTED_CLEARANCE:
-        color = color_orange;
+        color = COLOR_ORANGE;
         break;
       case MovementPhaseState::CAUTION_CONFLICTING_TRAFFIC:
-        color = color_orange;
+        color = COLOR_ORANGE;
         break;
       default:
-        color = color_grey;
+        color = COLOR_GREY;
         break;
   }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
@@ -200,7 +200,7 @@ namespace access {
  * @param time The value inside the TimeMark message
  * @return Type as time_mark_value_interpretation 
  */
-time_mark_value_interpretation interpretTimeMarkValueType(const uint16_t time) {
+inline time_mark_value_interpretation interpretTimeMarkValueType(const uint16_t time) {
   time_mark_value_interpretation type;
 
   if (time == 36001) {
@@ -227,7 +227,7 @@ time_mark_value_interpretation interpretTimeMarkValueType(const uint16_t time) {
  * @param nanosec Elapsed nanoseconds since the start of the last full hour (timestamp)
  * @return Time in seconds refered to the given timestamp
  */
-float interpretTimeMarkValueAsSeconds(const uint16_t time, const int32_t seconds, const uint32_t nanosec) {
+inline float interpretTimeMarkValueAsSeconds(const uint16_t time, const int32_t seconds, const uint32_t nanosec) {
   // calculate elapsed seconds since the start of the last full hour  
   float abs_time_hour = ((int)(seconds)) % 3600 + (float)nanosec * 1e-9;
   float rel_time_until_change = (float)time * 0.1f - abs_time_hour;
@@ -243,7 +243,7 @@ float interpretTimeMarkValueAsSeconds(const uint16_t time, const int32_t seconds
  * @param nanosec Elapsed nanoseconds since the start of the last full hour (timestamp)
  * @return Decoded String representation of the encoded time
  */
-std::string parseTimeMarkValueToString(const uint16_t time, const int32_t seconds, const uint32_t nanosec)
+inline std::string parseTimeMarkValueToString(const uint16_t time, const int32_t seconds, const uint32_t nanosec)
 {
   time_mark_value_interpretation time_type = interpretTimeMarkValueType(time);
 
@@ -272,6 +272,6 @@ std::string parseTimeMarkValueToString(const uint16_t time, const int32_t second
   return text_content;
 }
 
-
 } // namespace etsi_its_spatem_ts_msgs
+
 } // namespace access


### PR DESCRIPTION

- A new method has been added that returns the delta time in nanoseconds between an ETSI TimeMark and a UTC timestamp.
- An additional check has also been added to the delta time calculation to ensure that the TimeMark and TimeStamp fall within the same hour of the day. 
- Constant naming from lowercase to uppercase letters.


