### PR TITLE
Fix/spatem time mark interpretation

### DIFF
--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
@@ -234,7 +234,7 @@ inline time_mark_value_interpretation interpretTimeMarkValueType(const uint16_t 
   * @param nanosec Timestamp in nanoseconds
   * @return Delta time between the time stamp and the next time mark in nanoseconds
   */
- inline int64_t interpretTimeMarkValueAsNanoSeconds(const uint16_t time, const uint64_t nanosec) {
+ inline int64_t interpretTimeMarkDeltaTimeAsNanoSeconds(const uint16_t time, const uint64_t nanosec) {
   // calculate elapsed nanoseconds since the start of the last full hour in nanoseconds 
   int64_t abs_time_hour_nanosec = ((nanosec) % (HOUR_IN_SECONDS * FACTOR_SECONDS_TO_NANOSECONDS));
   int64_t abs_time_decoded_nanosec = static_cast<int64_t>(time) * FACTOR_ETSI_TIMEMARK_TO_SECONDS * FACTOR_SECONDS_TO_NANOSECONDS;

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/spatem/spatem_ts_utils.h
@@ -237,7 +237,7 @@ inline time_mark_value_interpretation interpretTimeMarkValueType(const uint16_t 
  inline int64_t interpretTimeMarkValueAsNanoSeconds(const uint16_t time, const uint64_t nanosec) {
   // calculate elapsed nanoseconds since the start of the last full hour in nanoseconds 
   int64_t abs_time_hour_nanosec = ((nanosec) % (HOUR_IN_SECONDS * FACTOR_SECONDS_TO_NANOSECONDS));
-  int64_t abs_time_decoded_nanosec = static_cast<int64_t>(time) * FACTOR_ETSI_TIMEMARK_TO_SECONDS;
+  int64_t abs_time_decoded_nanosec = static_cast<int64_t>(time) * FACTOR_ETSI_TIMEMARK_TO_SECONDS * FACTOR_SECONDS_TO_NANOSECONDS;
   int64_t rel_time_until_change =  abs_time_decoded_nanosec - abs_time_hour_nanosec;
 
   // adjust relative time if a jump to the next hour occurs (relative time inside the interval [-30:00, 30:00] )

--- a/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/MAPEM/mapem_display.cpp
@@ -471,7 +471,7 @@ void MAPEMDisplay::update(float, float) {
     
     // set pose of the corresponding utm scene node
     if (scene_nodes_utm_.find(utm_frame_key) == scene_nodes_utm_.end()) {
-      Ogre::SceneNode* scene_node = scene_node_->createChildSceneNode(utm_frame_key);
+      Ogre::SceneNode* scene_node = scene_node_->createChildSceneNode();
       scene_nodes_utm_.insert({utm_frame_key, scene_node});
     }
 
@@ -482,7 +482,7 @@ void MAPEMDisplay::update(float, float) {
     uint intersection_id = intsctn.getIntersectionID();
 
     if (scene_nodes_junctions_.find(intersection_id) == scene_nodes_junctions_.end()) {
-      Ogre::SceneNode* scene_node = scene_nodes_utm_[utm_frame_key]->createChildSceneNode(std::string("Junction: ") + std::to_string(intersection_id));
+      Ogre::SceneNode* scene_node = scene_nodes_utm_[utm_frame_key]->createChildSceneNode();
       scene_nodes_junctions_.insert({intersection_id, scene_node});
     }
 


### PR DESCRIPTION
Pull Request changes:

- Fix  faulty time conversion
- Change Method name for time conversion 
- Remove forced Ogre3D Node names to prevent crashes of Rviz when duplicate Nodes with the same name are created