### PR TITLE
Fix getter/setter convenience access functions for BIT_STRING

### DIFF
--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/asn1_primitives/asn1_primitives_getters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/asn1_primitives/asn1_primitives_getters.h
@@ -40,6 +40,7 @@ SOFTWARE.
  * @return std::vector<bool>
  */
 inline std::vector<bool> getBitString(const std::vector<uint8_t>& buffer, const int bits_unused) {
+
   // bit string size
   const int bits_per_byte = 8;
   const int n_bytes = buffer.size();
@@ -47,20 +48,21 @@ inline std::vector<bool> getBitString(const std::vector<uint8_t>& buffer, const 
   std::vector<bool> bits;
   bits.resize(n_bits - bits_unused, 0);
 
-  // loop over bytes in reverse order
-  for (int byte_idx = n_bytes - 1; byte_idx >= 0; byte_idx--) {
-      // loop over bits in a byte
-      for (int bit_idx_in_byte = bits_per_byte - 1; bit_idx_in_byte >= 0; bit_idx_in_byte--) {
-        
-        // map bit index in byte to bit index in total bitstring
-        int bit_idx = (n_bytes - byte_idx - 1) * bits_per_byte + bit_idx_in_byte;
-        if (byte_idx == 0 && bit_idx < bits_unused) break;
+  // loop over bytes
+  for (int byte_idx = 0; byte_idx < n_bytes; byte_idx++) {
 
-        // extract bit from bitstring and set output array entry appropriately
-        bool byte_has_true_bit = buffer[byte_idx] & (1 << bit_idx_in_byte);
-        if (byte_has_true_bit) bits[bits_per_byte-bit_idx-1] = true;
-      }
+    // loop over bits in a byte
+    for (int bit_idx_in_byte = 0; bit_idx_in_byte < bits_per_byte; bit_idx_in_byte++) {
+
+      // map bit index in byte to bit index in total bitstring
+      int bit_idx = bit_idx_in_byte + byte_idx * bits_per_byte;
+      if ((byte_idx + 1) >= n_bytes && (bit_idx_in_byte + bits_unused) >= bits_per_byte) break;
+
+      // extract bit from bitstring and set output array entry appropriately
+      bool byte_has_true_bit = static_cast<bool>(buffer[byte_idx] & (1 << (bits_per_byte - 1 - bit_idx_in_byte)));
+      if (byte_has_true_bit) bits[bit_idx] = true;
     }
+  }
   return bits;
 }
 

--- a/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/asn1_primitives/asn1_primitives_setters.h
+++ b/etsi_its_msgs_utils/include/etsi_its_msgs_utils/impl/asn1_primitives/asn1_primitives_setters.h
@@ -41,29 +41,28 @@ SOFTWARE.
  */
 template <typename T>
 inline void setBitString(T& bitstring, const std::vector<bool>& bits) {
+
   // bit string size
   const int bits_per_byte = 8;
-  const int n_bytes = (bits.size() - 1) / bits_per_byte + 1;
+  const int n_bytes = static_cast<int>((bits.size() - 1) / bits_per_byte) + 1;
   const int n_bits = n_bytes * bits_per_byte;
 
   // init output
   bitstring.bits_unused = n_bits - bits.size();
   bitstring.value = std::vector<uint8_t>(n_bytes);
 
-  // loop over all bytes in reverse order
-  for (int byte_idx = n_bytes - 1; byte_idx >= 0; byte_idx--) {
+  // loop over all bytes
+  for (int byte_idx = 0; byte_idx < n_bytes; byte_idx++) {
 
     // loop over bits in a byte
-    for (int bit_idx_in_byte = bits_per_byte - 1; bit_idx_in_byte >= 0; bit_idx_in_byte--) {
+    for (int bit_idx_in_byte = 0; bit_idx_in_byte < bits_per_byte; bit_idx_in_byte++) {
 
       // map bit index in byte to bit index in total bitstring
-      int bit_idx = (n_bytes - byte_idx - 1) * bits_per_byte + bit_idx_in_byte;
-      if (byte_idx == 0 && bit_idx < bitstring.bits_unused) break;
+      int bit_idx = bit_idx_in_byte + byte_idx * bits_per_byte;
+      if ((byte_idx + 1) >= n_bytes && (bit_idx_in_byte + bitstring.bits_unused) >= bits_per_byte) break;
 
       // set bit in output bitstring appropriately
-      if (bit_idx < bits.size()) {
-        bitstring.value[byte_idx] |= bits[bits_per_byte - bit_idx - 1] << bit_idx_in_byte;
-      }
+      bitstring.value[byte_idx] |= bits[bit_idx] << (bits_per_byte - 1 - bit_idx_in_byte);
     }
   }
 }

--- a/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
+++ b/etsi_its_msgs_utils/test/impl/test_cam_access.cpp
@@ -185,4 +185,14 @@ TEST(etsi_its_cam_msgs, test_set_get_cam) {
       cam_msgs::LowFrequencyContainer::CHOICE_BASIC_VEHICLE_CONTAINER_LOW_FREQUENCY;
   cam_access::setExteriorLights(cam, exterior_lights);
   EXPECT_EQ(exterior_lights, cam_access::getExteriorLights(cam));
+
+  std::vector<uint8_t> expected_bit_string = {0b10101010, 0b10100000};
+  std::vector<bool> expected_bit_string_bools = {true, false, true, false, true, false, true, false, true, false, true, false};
+  std::vector<bool> bit_string_bools = cam_access::getBitString(expected_bit_string, 4);
+  EXPECT_EQ(expected_bit_string_bools, bit_string_bools);
+  cam_msgs::DrivingLaneStatus driving_lane_status;
+  cam_access::setBitString(driving_lane_status, expected_bit_string_bools);
+  EXPECT_EQ(expected_bit_string, driving_lane_status.value);
+  std::vector<bool> bit_string_bools_per_getter = cam_access::getDrivingLaneStatus(driving_lane_status);
+  EXPECT_EQ(expected_bit_string_bools, bit_string_bools_per_getter);
 }


### PR DESCRIPTION
### Problem

- motivated by #104, the getters/setters for BIT_STRING were re-investigated
- getters/setters for BIT_STRING were wrongly fixed in #55 to produce the expected getter output for the ID.3 test data (see GitLab issue 47)
  - ID.3 test case was only working correctly cause [`ExteriorLights`](https://github.com/ika-rwth-aachen/etsi_its_messages/blob/main/etsi_its_msgs/etsi_its_cam_msgs/msg/ExteriorLights.msg) only needs 8 bits / 1 byte with `bits_unused = 0`
  - getter output for fields with more than 1 byte and non-zero `bits_unused` was wrong, e.g., example from #104 even crashed
- [here is a simple test program illustrating the problem and the fix](https://godbolt.org/z/a7PzbfTrh)

### Solution

- getters/setters for BIT_STRING were fixed
  - loops over bytes and bits don't operate in reverse order anymore, which made things unnecessarily confusing after the changes of #55

### Testing

- tests were extended to also cover the case from #104 
- previously existing tests for `ExteriorLights` remain unchanged and still pass, so the conclusions of GitLab issue 47 should still remain valid