### PR TITLE
Fix setting of BTP destination port in `udp_msg.src_port`

### DIFF
--- a/etsi_its_conversion/etsi_its_conversion/src/Converter.cpp
+++ b/etsi_its_conversion/etsi_its_conversion/src/Converter.cpp
@@ -372,8 +372,8 @@ UdpPacket Converter::bufferToUdpPacketMessage(const uint8_t* buffer, const int s
   UdpPacket udp_msg;
 
   // add BTP destination port and destination port info
+  udp_msg.src_port = btp_header_destination_port;
   uint16_t destination_port = htons(btp_header_destination_port);
-  udp_msg.src_port = destination_port;
   if (has_btp_destination_port_) {
     uint16_t destination_port_info = 0;
     uint16_t* btp_header = new uint16_t[2] {destination_port, destination_port_info};


### PR DESCRIPTION
Fixes a minor bug introduced with the new feature from https://github.com/ika-rwth-aachen/etsi_its_messages/pull/100.
- `udp_msg.src_port` field was used to also carry the information about the BTP destination port
- instead of network byte order, we should fill the value with host byte order (before the call to `htons`)
- before, the field was set to `53511` (`0xd107`) for CAM instead of `2001` (`0x07d1`)
- the other way around, the field is also interpreted as host byte order, so this was definitely a bug

FYI: @Tezozomoc47 