### PR TITLE
Add CAM display capable of subscribing to both CAM and CAM TS

### DIFF
--- a/etsi_its_rviz_plugins/CMakeLists.txt
+++ b/etsi_its_rviz_plugins/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(etsi_its_cam_msgs REQUIRED)
+find_package(etsi_its_cam_ts_msgs REQUIRED)
 find_package(etsi_its_cpm_ts_msgs REQUIRED)
 find_package(etsi_its_denm_msgs REQUIRED)
 find_package(etsi_its_mapem_ts_msgs REQUIRED)
@@ -68,6 +69,7 @@ ament_target_dependencies(${PROJECT_NAME}
   PUBLIC
   rclcpp
   etsi_its_cam_msgs
+  etsi_its_cam_ts_msgs
   etsi_its_cpm_ts_msgs
   etsi_its_denm_msgs
   etsi_its_mapem_ts_msgs
@@ -85,6 +87,7 @@ ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 ament_export_dependencies(
   etsi_its_cam_msgs
+  etsi_its_cam_ts_msgs
   etsi_its_cpm_ts_msgs
   etsi_its_denm_msgs
   etsi_its_mapem_ts_msgs

--- a/etsi_its_rviz_plugins/config/demo.rviz
+++ b/etsi_its_rviz_plugins/config/demo.rviz
@@ -49,42 +49,23 @@ Visualization Manager:
     - Class: rviz_common/Group
       Displays:
         - Class: etsi_its_msgs/CAM
+          Color: 0; 170; 255
           Enabled: true
+          Metadata:
+            Color: 0; 170; 255
+            Scale: 4
+            Speed: true
+            StationID: true
+            Value: true
           Name: CAM
+          Scale: 1
+          Timeout: 2
           Topic:
             Depth: 5
             Durability Policy: Volatile
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /etsi_its_conversion/cam/out
-          CAM TS Topic:
-            Depth: 5
-            Durability Policy: Volatile
-            History Policy: Keep Last
-            Reliability Policy: Reliable
-            Value: /etsi_its_conversion/cam_ts/out
-          Visualize CAMs:
-            Value: true
-            Timeout: 2
-            Scale: 1
-            Color: 0; 170; 255
-            Metadata:
-              Value: true
-              Scale: 4
-              StationID: true
-              Speed: true
-              Color: 0; 170; 255
-          Visualize CAMs TS:
-            Value: true
-            Timeout: 2
-            Scale: 1
-            Color: 0; 170; 255
-            Metadata:
-              Value: true
-              Scale: 4
-              StationID: true
-              Speed: true
-              Color: 0; 170; 255
           Value: true
         - Class: etsi_its_msgs/DENM
           Color: 255; 0; 25
@@ -157,42 +138,23 @@ Visualization Manager:
     - Class: rviz_common/Group
       Displays:
         - Class: etsi_its_msgs/CAM
+          Color: 0; 170; 255
           Enabled: true
+          Metadata:
+            Color: 0; 170; 255
+            Scale: 4
+            Speed: true
+            StationID: true
+            Value: true
           Name: CAM
+          Scale: 1
+          Timeout: 2
           Topic:
             Depth: 5
             Durability Policy: Volatile
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /etsi_its_conversion/cam/in
-          CAM TS Topic:
-            Depth: 5
-            Durability Policy: Volatile
-            History Policy: Keep Last
-            Reliability Policy: Reliable
-            Value: /etsi_its_conversion/cam_ts/in
-          Visualize CAMs:
-            Value: true
-            Timeout: 2
-            Scale: 1
-            Color: 0; 170; 255
-            Metadata:
-              Value: true
-              Scale: 4
-              StationID: true
-              Speed: true
-              Color: 0; 170; 255
-          Visualize CAMs TS:
-            Value: true
-            Timeout: 2
-            Scale: 1
-            Color: 0; 170; 255
-            Metadata:
-              Value: true
-              Scale: 4
-              StationID: true
-              Speed: true
-              Color: 0; 170; 255
           Value: true
         - Class: etsi_its_msgs/DENM
           Color: 255; 0; 25

--- a/etsi_its_rviz_plugins/config/demo.rviz
+++ b/etsi_its_rviz_plugins/config/demo.rviz
@@ -49,23 +49,42 @@ Visualization Manager:
     - Class: rviz_common/Group
       Displays:
         - Class: etsi_its_msgs/CAM
-          Color: 0; 170; 255
           Enabled: true
-          Metadata:
-            Color: 0; 170; 255
-            Scale: 4
-            Speed: true
-            StationID: true
-            Value: true
           Name: CAM
-          Scale: 1
-          Timeout: 2
           Topic:
             Depth: 5
             Durability Policy: Volatile
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /etsi_its_conversion/cam/out
+          CAM TS Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /etsi_its_conversion/cam_ts/out
+          Visualize CAMs:
+            Value: true
+            Timeout: 2
+            Scale: 1
+            Color: 0; 170; 255
+            Metadata:
+              Value: true
+              Scale: 4
+              StationID: true
+              Speed: true
+              Color: 0; 170; 255
+          Visualize CAMs TS:
+            Value: true
+            Timeout: 2
+            Scale: 1
+            Color: 0; 170; 255
+            Metadata:
+              Value: true
+              Scale: 4
+              StationID: true
+              Speed: true
+              Color: 0; 170; 255
           Value: true
         - Class: etsi_its_msgs/DENM
           Color: 255; 0; 25
@@ -138,23 +157,42 @@ Visualization Manager:
     - Class: rviz_common/Group
       Displays:
         - Class: etsi_its_msgs/CAM
-          Color: 0; 170; 255
           Enabled: true
-          Metadata:
-            Color: 0; 170; 255
-            Scale: 4
-            Speed: true
-            StationID: true
-            Value: true
           Name: CAM
-          Scale: 1
-          Timeout: 2
           Topic:
             Depth: 5
             Durability Policy: Volatile
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /etsi_its_conversion/cam/in
+          CAM TS Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /etsi_its_conversion/cam_ts/in
+          Visualize CAMs:
+            Value: true
+            Timeout: 2
+            Scale: 1
+            Color: 0; 170; 255
+            Metadata:
+              Value: true
+              Scale: 4
+              StationID: true
+              Speed: true
+              Color: 0; 170; 255
+          Visualize CAMs TS:
+            Value: true
+            Timeout: 2
+            Scale: 1
+            Color: 0; 170; 255
+            Metadata:
+              Value: true
+              Scale: 4
+              StationID: true
+              Speed: true
+              Color: 0; 170; 255
           Value: true
         - Class: etsi_its_msgs/DENM
           Color: 255; 0; 25

--- a/etsi_its_rviz_plugins/include/displays/CAM/cam_display.hpp
+++ b/etsi_its_rviz_plugins/include/displays/CAM/cam_display.hpp
@@ -25,6 +25,7 @@ SOFTWARE.
 #pragma once
 
 #include "etsi_its_cam_msgs/msg/cam.hpp"
+#include "etsi_its_cam_ts_msgs/msg/cam.hpp"
 
 #include "displays/CAM/cam_render_object.hpp"
 
@@ -45,6 +46,8 @@ namespace properties
 {
   class ColorProperty;
   class FloatProperty;
+  class RosTopicProperty;
+  class QosProfileProperty;
 }  // namespace properties
 }  // namespace rviz_common
 
@@ -70,22 +73,46 @@ public:
 
   void reset() override;
 
+protected Q_SLOTS:
+  void changedCAMViz();
+  void changedCAMTSViz();
+  void changedCAMTSTopic();
+
 protected:
+  // Base-class override so the class is not abstract
   void processMessage(etsi_its_cam_msgs::msg::CAM::ConstSharedPtr msg) override;
+
+  // Unified handler that accepts either CAM (release 1) or CAM TS (release 2)
+  void processMessage(const std::variant<
+    etsi_its_cam_msgs::msg::CAM,
+    etsi_its_cam_ts_msgs::msg::CAM
+  > & msg_variant);
+
   void update(float wall_dt, float ros_dt) override;
 
   Ogre::ManualObject * manual_object_;
 
   rclcpp::Node::SharedPtr rviz_node_;
 
-  // Properties
-  rviz_common::properties::BoolProperty *show_meta_, *show_station_id_, *show_speed_;
+  // CAM (release 1) properties
+  rviz_common::properties::BoolProperty *viz_cam_, *show_meta_, *show_station_id_, *show_speed_;
   rviz_common::properties::FloatProperty *buffer_timeout_, *bb_scale_, *char_height_;
   rviz_common::properties::ColorProperty *color_property_, *text_color_property_;
+
+  // CAM TS (release 2) properties
+  rviz_common::properties::BoolProperty *viz_cam_ts_, *show_meta_ts_, *show_station_id_ts_, *show_speed_ts_;
+  rviz_common::properties::FloatProperty *buffer_timeout_ts_, *bb_scale_ts_, *char_height_ts_;
+  rviz_common::properties::ColorProperty *color_property_ts_, *text_color_property_ts_;
+  rviz_common::properties::RosTopicProperty *cam_ts_topic_property_;
+  rviz_common::properties::QosProfileProperty *cam_ts_qos_property_;
+  rclcpp::QoS cam_ts_qos_profile_ = rclcpp::QoS(1);
+  rclcpp::Subscription<etsi_its_cam_ts_msgs::msg::CAM>::SharedPtr cam_ts_sub_;
 
   std::unordered_map<int, CAMRenderObject> cams_;
   std::vector<std::shared_ptr<rviz_rendering::Shape>> bboxs_;
   std::vector<std::shared_ptr<rviz_rendering::MovableText>> texts_;
+
+  uint64_t received_ts_ = 0;
 };
 
 }  // namespace displays

--- a/etsi_its_rviz_plugins/include/displays/CAM/cam_display.hpp
+++ b/etsi_its_rviz_plugins/include/displays/CAM/cam_display.hpp
@@ -46,8 +46,6 @@ namespace properties
 {
   class ColorProperty;
   class FloatProperty;
-  class RosTopicProperty;
-  class QosProfileProperty;
 }  // namespace properties
 }  // namespace rviz_common
 
@@ -60,8 +58,7 @@ namespace displays
  * @class CAMDisplay
  * @brief Displays an etsi_its_cam_msgs::CAM
  */
-class CAMDisplay : public
-  rviz_common::RosTopicDisplay<etsi_its_cam_msgs::msg::CAM>
+class CAMDisplay : public rviz_common::_RosTopicDisplay
 {
   Q_OBJECT
 
@@ -73,46 +70,52 @@ public:
 
   void reset() override;
 
+  void setTopic(const QString & topic, const QString & datatype) override;
+
 protected Q_SLOTS:
-  void changedCAMViz();
-  void changedCAMTSViz();
-  void changedCAMTSTopic();
+  void updateTopic() override;
 
 protected:
-  // Base-class override so the class is not abstract
-  void processMessage(etsi_its_cam_msgs::msg::CAM::ConstSharedPtr msg) override;
+  // CAM type detection
+  enum class CamType
+  {
+    NONE,
+    RELEASE_1,
+    RELEASE_2
+  };
+  CamType detectCamType(const std::string & topic);
+
+  void subscribe();
+  void unsubscribe();
+  void onEnable() override;
+  void onDisable() override;
 
   // Unified handler that accepts either CAM (release 1) or CAM TS (release 2)
   void processMessage(const std::variant<
-    etsi_its_cam_msgs::msg::CAM,
-    etsi_its_cam_ts_msgs::msg::CAM
-  > & msg_variant);
+      etsi_its_cam_msgs::msg::CAM,
+      etsi_its_cam_ts_msgs::msg::CAM
+    > & msg_variant);
 
   void update(float wall_dt, float ros_dt) override;
 
   Ogre::ManualObject * manual_object_;
 
   rclcpp::Node::SharedPtr rviz_node_;
+  std::shared_ptr<rclcpp::SubscriptionBase> subscription_;
+  rclcpp::TimerBase::SharedPtr topic_check_timer_;
 
-  // CAM (release 1) properties
-  rviz_common::properties::BoolProperty *viz_cam_, *show_meta_, *show_station_id_, *show_speed_;
+  CamType active_cam_type_;
+  rclcpp::Time subscription_start_time_;
+  uint32_t messages_received_;
+
+  // Properties
+  rviz_common::properties::BoolProperty *show_meta_, *show_station_id_, *show_speed_;
   rviz_common::properties::FloatProperty *buffer_timeout_, *bb_scale_, *char_height_;
   rviz_common::properties::ColorProperty *color_property_, *text_color_property_;
-
-  // CAM TS (release 2) properties
-  rviz_common::properties::BoolProperty *viz_cam_ts_, *show_meta_ts_, *show_station_id_ts_, *show_speed_ts_;
-  rviz_common::properties::FloatProperty *buffer_timeout_ts_, *bb_scale_ts_, *char_height_ts_;
-  rviz_common::properties::ColorProperty *color_property_ts_, *text_color_property_ts_;
-  rviz_common::properties::RosTopicProperty *cam_ts_topic_property_;
-  rviz_common::properties::QosProfileProperty *cam_ts_qos_property_;
-  rclcpp::QoS cam_ts_qos_profile_ = rclcpp::QoS(1);
-  rclcpp::Subscription<etsi_its_cam_ts_msgs::msg::CAM>::SharedPtr cam_ts_sub_;
 
   std::unordered_map<int, CAMRenderObject> cams_;
   std::vector<std::shared_ptr<rviz_rendering::Shape>> bboxs_;
   std::vector<std::shared_ptr<rviz_rendering::MovableText>> texts_;
-
-  uint64_t received_ts_ = 0;
 };
 
 }  // namespace displays

--- a/etsi_its_rviz_plugins/include/displays/CAM/cam_render_object.hpp
+++ b/etsi_its_rviz_plugins/include/displays/CAM/cam_render_object.hpp
@@ -23,6 +23,7 @@ SOFTWARE.
 ============================================================================= */
 
 #include "etsi_its_cam_msgs/msg/cam.hpp"
+#include "etsi_its_cam_ts_msgs/msg/cam.hpp"
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <std_msgs/msg/header.hpp>
@@ -30,8 +31,11 @@ SOFTWARE.
 
 #include <tf2/LinearMath/Quaternion.h>
 #include <etsi_its_msgs_utils/cam_access.hpp>
+#include <etsi_its_msgs_utils/cam_ts_access.hpp>
 
 #include "rviz_common/validate_floats.hpp"
+#include <variant>
+#include <cmath>
 
 namespace etsi_its_msgs
 {
@@ -45,7 +49,18 @@ namespace displays
 class CAMRenderObject
 {
   public:
-    CAMRenderObject(etsi_its_cam_msgs::msg::CAM cam, rclcpp::Time receive_time, uint16_t n_leap_seconds=etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.rbegin()->second);
+    CAMRenderObject(const std::variant<
+                      etsi_its_cam_msgs::msg::CAM,
+                      etsi_its_cam_ts_msgs::msg::CAM
+                    > & cam_variant,
+                    rclcpp::Time receive_time,
+                    uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.rbegin()->second);
+
+    CAMRenderObject(const etsi_its_cam_msgs::msg::CAM & cam, rclcpp::Time receive_time, uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.rbegin()->second)
+      : CAMRenderObject(std::variant<etsi_its_cam_msgs::msg::CAM, etsi_its_cam_ts_msgs::msg::CAM>(cam), receive_time, n_leap_seconds) {}
+
+    CAMRenderObject(const etsi_its_cam_ts_msgs::msg::CAM & cam, rclcpp::Time receive_time, uint16_t n_leap_seconds = etsi_its_msgs::LEAP_SECOND_INSERTIONS_SINCE_2004.rbegin()->second)
+      : CAMRenderObject(std::variant<etsi_its_cam_msgs::msg::CAM, etsi_its_cam_ts_msgs::msg::CAM>(cam), receive_time, n_leap_seconds) {}
 
     /**
      * @brief This function validates all float variables that are part of a CAMRenderObject
@@ -103,6 +118,13 @@ class CAMRenderObject
      */
     double getSpeed();
 
+    /**
+     * @brief Check if the CAM object is TS (release 2)
+     *
+     * @return true if CAM object is TS, false otherwise
+     */
+    bool isTS();
+
   private:
     // member variables
     std_msgs::msg::Header header;
@@ -111,7 +133,7 @@ class CAMRenderObject
     geometry_msgs::msg::Pose pose;
     geometry_msgs::msg::Vector3 dimensions;
     double speed;
-
+    bool is_ts = false;
 };
 
 }  // namespace displays

--- a/etsi_its_rviz_plugins/package.xml
+++ b/etsi_its_rviz_plugins/package.xml
@@ -22,6 +22,7 @@
   <build_depend>qtbase5-dev</build_depend>
   <build_export_depend>rviz_ogre_vendor</build_export_depend>
   <depend>etsi_its_cam_msgs</depend>
+  <depend>etsi_its_cam_ts_msgs</depend>
   <depend>etsi_its_cpm_ts_msgs</depend>
   <depend>etsi_its_denm_msgs</depend>
   <depend>etsi_its_mapem_ts_msgs</depend>

--- a/etsi_its_rviz_plugins/plugins_description.xml
+++ b/etsi_its_rviz_plugins/plugins_description.xml
@@ -7,9 +7,10 @@
     base_class_type="rviz_common::Display"
   >
     <description>
-      Displays data from a etsi_its_cam_msgs::CAM.
+      Displays data from a etsi_its_cam_msgs::CAM and/or a etsi_its_cam_ts_msgs::CAM.
     </description>
     <message_type>etsi_its_cam_msgs/msg/CAM</message_type>
+    <message_type>etsi_its_cam_ts_msgs/msg/CAM</message_type>
   </class>
 
   <class

--- a/etsi_its_rviz_plugins/plugins_description.xml
+++ b/etsi_its_rviz_plugins/plugins_description.xml
@@ -7,7 +7,7 @@
     base_class_type="rviz_common::Display"
   >
     <description>
-      Displays data from a etsi_its_cam_msgs::CAM and/or a etsi_its_cam_ts_msgs::CAM.
+      Displays data from a etsi_its_cam_msgs::CAM or a etsi_its_cam_ts_msgs::CAM.
     </description>
     <message_type>etsi_its_cam_msgs/msg/CAM</message_type>
     <message_type>etsi_its_cam_ts_msgs/msg/CAM</message_type>

--- a/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
@@ -38,8 +38,6 @@ SOFTWARE.
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/float_property.hpp"
 #include "rviz_common/properties/bool_property.hpp"
-#include "rviz_common/properties/ros_topic_property.hpp"
-#include "rviz_common/properties/qos_profile_property.hpp"
 
 #include "rviz_common/properties/parse_color.hpp"
 
@@ -49,23 +47,23 @@ namespace displays
 {
 
 CAMDisplay::CAMDisplay()
+  : active_cam_type_(CamType::NONE),
+    messages_received_(0)
 {
-  // CAM (release 1) properties
-  viz_cam_ = new rviz_common::properties::BoolProperty("Visualize CAMs", true,
-    "Show CAM (release 1) messages", this, SLOT(changedCAMViz()));
+  // General Properties
   buffer_timeout_ = new rviz_common::properties::FloatProperty(
     "Timeout", 0.1f,
-    "Time (in s) until objects disappear", viz_cam_);
+    "Time (in s) until objects disappear", this);
   buffer_timeout_->setMin(0);
   bb_scale_ = new rviz_common::properties::FloatProperty(
     "Scale", 1.0f,
-    "Scale of objects", viz_cam_);
+    "Scale of objects", this);
   bb_scale_->setMin(0.01);
   color_property_ = new rviz_common::properties::ColorProperty(
     "Color", QColor(25, 0, 255),
-    "Object color", viz_cam_);
+    "Object color", this);
   show_meta_ = new rviz_common::properties::BoolProperty("Metadata", true,
-    "Show metadata as text next to objects", viz_cam_);
+    "Show metadata as text next to objects", this);
   text_color_property_ = new rviz_common::properties::ColorProperty(
     "Color", QColor(25, 0, 255),
     "Text color", show_meta_);
@@ -75,35 +73,7 @@ CAMDisplay::CAMDisplay()
   show_speed_ = new rviz_common::properties::BoolProperty("Speed", true,
     "Show speed", show_meta_);
 
-  // CAM TS (release 2) properties
-  cam_ts_topic_property_ = new rviz_common::properties::RosTopicProperty(
-    "CAM TS Topic", "/etsi_its_conversion/cam_ts/out",
-    rosidl_generator_traits::data_type<etsi_its_cam_ts_msgs::msg::CAM>(),
-    "Topic of CAM TS (release 2) messages", this, SLOT(changedCAMTSTopic()));
-  cam_ts_qos_property_ = new rviz_common::properties::QosProfileProperty(cam_ts_topic_property_, cam_ts_qos_profile_);
-  viz_cam_ts_ = new rviz_common::properties::BoolProperty("Visualize CAMs TS", false,
-    "Show CAM TS (release 2) messages", this, SLOT(changedCAMTSViz()));
-  buffer_timeout_ts_ = new rviz_common::properties::FloatProperty(
-    "Timeout", 0.1f,
-    "Time (in s) until objects disappear", viz_cam_ts_);
-  buffer_timeout_ts_->setMin(0);
-  bb_scale_ts_ = new rviz_common::properties::FloatProperty(
-    "Scale", 1.0f,
-    "Scale of objects", viz_cam_ts_);
-  bb_scale_ts_->setMin(0.01);
-  color_property_ts_ = new rviz_common::properties::ColorProperty(
-    "Color", QColor(25, 0, 255),
-    "Object color", viz_cam_ts_);
-  show_meta_ts_ = new rviz_common::properties::BoolProperty("Metadata", true,
-    "Show metadata as text next to objects", viz_cam_ts_);
-  text_color_property_ts_ = new rviz_common::properties::ColorProperty(
-    "Color", QColor(25, 0, 255),
-    "Text color", show_meta_ts_);
-  char_height_ts_ = new rviz_common::properties::FloatProperty("Scale", 4.0, "Scale of text", show_meta_ts_);
-  show_station_id_ts_ = new rviz_common::properties::BoolProperty("StationID", true,
-    "Show StationID", show_meta_ts_);
-  show_speed_ts_ = new rviz_common::properties::BoolProperty("Speed", true,
-    "Show speed", show_meta_ts_);
+  topic_property_->setDescription("etsi_its_cam_msgs/msg/CAM or etsi_its_cam_ts_msgs/msg/CAM topic to subscribe to.");
 }
 
 CAMDisplay::~CAMDisplay()
@@ -115,18 +85,10 @@ CAMDisplay::~CAMDisplay()
 
 void CAMDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  rviz_common::_RosTopicDisplay::onInitialize();
 
   auto nodeAbstraction = context_->getRosNodeAbstraction().lock();
   rviz_node_ = nodeAbstraction->get_raw_node();
-
-  // Initialize topic and QoS properties for CAM TS
-  cam_ts_topic_property_->initialize(nodeAbstraction);
-  cam_ts_qos_property_->initialize(
-      [this](rclcpp::QoS profile) {
-        cam_ts_qos_profile_ = profile;
-        changedCAMTSTopic();
-      });
 
   manual_object_ = scene_manager_->createManualObject();
   manual_object_->setDynamic(true);
@@ -135,77 +97,146 @@ void CAMDisplay::onInitialize()
 
 void CAMDisplay::reset()
 {
-  RTDClass::reset();
+  Display::reset();
   manual_object_->clear();
-  cam_ts_sub_.reset();
+  cams_.clear();
+  messages_received_ = 0;
 }
 
-void CAMDisplay::changedCAMViz() {
-  if(!viz_cam_->getBool()) {
-    deleteStatus("Topic");
+void CAMDisplay::setTopic(const QString & topic, const QString & datatype)
+{
+  (void) datatype;
+  topic_property_->setString(topic);
+}
+
+void CAMDisplay::updateTopic()
+{
+  std::cout << "CAMDisplay::updateTopic()" << std::endl;
+  unsubscribe();
+  reset();
+  subscribe();
+  context_->queueRender();
+}
+
+CAMDisplay::CamType CAMDisplay::detectCamType(const std::string & topic)
+{
+  auto topics = rviz_node_->get_topic_names_and_types();
+
+  auto it = topics.find(topic);
+  if (it == topics.end()) {
+    return CamType::NONE;
   }
-}
 
-void CAMDisplay::changedCAMTSViz() {
-  if(!viz_cam_ts_->getBool()) {
-    deleteStatus("CAM TS Topic");
-    cam_ts_sub_.reset();
-  } 
-  else changedCAMTSTopic();
-}
-
-void CAMDisplay::changedCAMTSTopic() {
-  cam_ts_sub_.reset();
-  received_ts_ = 0;
-  if(cam_ts_topic_property_->isEmpty()) {
-    setStatus(
-        rviz_common::properties::StatusProperty::Warn,
-        "CAM TS Topic",
-        QString("Error subscribing: Empty topic name"));
-      return;
-  }
-
-  std::map<std::string, std::vector<std::string>> published_topics = rviz_node_->get_topic_names_and_types();
-  bool topic_available = false;
-  std::string topic_message_type;
-  for (const auto & topic : published_topics) {
-    // Only add topics whose type matches.
-    if(topic.first == cam_ts_topic_property_->getTopicStd()) {
-      topic_available = true;
-      for (const auto & type : topic.second) {
-        topic_message_type = type;
-        if (type == "etsi_its_cam_ts_msgs/msg/CAM") {
-          cam_ts_sub_ = rviz_node_->create_subscription<etsi_its_cam_ts_msgs::msg::CAM>(
-            cam_ts_topic_property_->getTopicStd(),
-            cam_ts_qos_profile_,
-            [this](const etsi_its_cam_ts_msgs::msg::CAM::SharedPtr msg) {
-              // Forward release 2 message to unified handler
-              this->processMessage(std::variant<etsi_its_cam_msgs::msg::CAM, etsi_its_cam_ts_msgs::msg::CAM>(*msg));
-            });
-          return;
-        }
-      }
+  for (const auto & type : it->second) {
+    if (type == "etsi_its_cam_ts_msgs/msg/CAM") {
+      return CamType::RELEASE_2;
+    }
+    if (type == "etsi_its_cam_msgs/msg/CAM") {
+      return CamType::RELEASE_1;
     }
   }
-  if(!topic_available) {
-    setStatus(
-      rviz_common::properties::StatusProperty::Warn, "CAM TS Topic",
-      QString("Error subscribing to ") + QString::fromStdString(cam_ts_topic_property_->getTopicStd())
-      + QString(": Topic is not available!"));
-  }
-  else {
-    setStatus(
-      rviz_common::properties::StatusProperty::Warn, "CAM TS Topic",
-      QString("Error subscribing to ") + QString::fromStdString(cam_ts_topic_property_->getTopicStd())
-      + QString(": Message type ") + QString::fromStdString(topic_message_type) + QString::fromStdString(" does not equal etsi_its_cam_ts_msgs::msg::CAM!"));
-  }
 
+  return CamType::NONE;
 }
 
-// Base-class override but delegate to the unified handler
-void CAMDisplay::processMessage(etsi_its_cam_msgs::msg::CAM::ConstSharedPtr msg)
+void CAMDisplay::subscribe()
 {
-  processMessage(std::variant<etsi_its_cam_msgs::msg::CAM, etsi_its_cam_ts_msgs::msg::CAM>(*msg));
+  if (!isEnabled() ) {
+    return;
+  }
+
+  unsubscribe();
+
+  if (topic_property_->isEmpty()) {
+    setStatus(
+      rviz_common::properties::StatusProperty::Error,
+      "Topic",
+      QString("Error subscribing: Empty topic name"));
+    return;
+  }
+
+  const std::string topic = topic_property_->getTopicStd();
+
+  // Validate topic name
+  try {
+    rclcpp::expand_topic_or_service_name(
+      topic,
+      rviz_node_->get_name(),
+      rviz_node_->get_namespace());
+  } catch (const rclcpp::exceptions::InvalidTopicNameError & e) {
+    setStatus(
+      rviz_common::properties::StatusProperty::Error,
+      "Topic",
+      QString("Error subscribing: ") + e.what());
+    return;
+  }
+
+  CamType cam_type = detectCamType(topic);
+
+  if (cam_type == CamType::RELEASE_1) {
+    subscription_ = rviz_node_->create_subscription<etsi_its_cam_msgs::msg::CAM>(
+      topic,
+      qos_profile,
+      [this](etsi_its_cam_msgs::msg::CAM::SharedPtr msg) {
+        processMessage(std::variant<etsi_its_cam_msgs::msg::CAM,etsi_its_cam_ts_msgs::msg::CAM>(*msg));
+      });
+    active_cam_type_ = CamType::RELEASE_1;
+  }
+  else if (cam_type == CamType::RELEASE_2) {
+    subscription_ = rviz_node_->create_subscription<etsi_its_cam_ts_msgs::msg::CAM>(
+      topic,
+      qos_profile,
+      [this](etsi_its_cam_ts_msgs::msg::CAM::ConstSharedPtr msg) {
+        this->processMessage(std::variant<etsi_its_cam_msgs::msg::CAM,etsi_its_cam_ts_msgs::msg::CAM>(*msg));
+      });
+    active_cam_type_ = CamType::RELEASE_2;
+  }
+  else { // cam_type == CamType::NONE, i.e. not found or wrong type
+    setStatus(
+      rviz_common::properties::StatusProperty::Warn, "Topic",
+      QString("Waiting for topic: ") + QString::fromStdString(topic)
+      + QString(" (etsi_its_cam_msgs/msg/CAM or etsi_its_cam_ts_msgs/msg/CAM)"));
+    
+    // Start periodic timer to check for topic availability
+    if (!topic_check_timer_) {
+      topic_check_timer_ = rviz_node_->create_wall_timer(
+        std::chrono::milliseconds(1000),
+        [this]() { subscribe(); });
+    }
+  }
+
+  if (subscription_) {
+    subscription_start_time_ = rviz_node_->now();
+    setStatus(rviz_common::properties::StatusProperty::Ok, "Topic", "OK");
+    // Cancel timer since the subscription was successful
+    if (topic_check_timer_) {
+      topic_check_timer_->cancel();
+      topic_check_timer_.reset();
+    }
+  }
+}
+
+void CAMDisplay::unsubscribe()
+{
+  subscription_.reset();
+  active_cam_type_ = CamType::NONE;
+
+  // Cancel the timer
+  if (topic_check_timer_) {
+    topic_check_timer_->cancel();
+    topic_check_timer_.reset();
+  }
+}
+
+void CAMDisplay::onEnable()
+{
+  subscribe();
+}
+
+void CAMDisplay::onDisable()
+{
+  unsubscribe();
+  reset();
 }
 
 // Unified handler used by both release 1 (base-class override delegates to this) and release 2 subscription lambda
@@ -226,16 +257,9 @@ void CAMDisplay::processMessage(const std::variant<
 
   CAMRenderObject cam(msg_variant, now, getLeapSecondInsertionsSince2004(static_cast<uint64_t>(now.seconds())));
   if (!cam.validateFloats()) {
-    // report error on the proper status entry depending on origin
-    if (cam.isTS()) {
-      setStatus(
-        rviz_common::properties::StatusProperty::Error, "CAM TS Topic",
-        "Message contained invalid floating point values (nans or infs)");
-    } else {
-      setStatus(
-        rviz_common::properties::StatusProperty::Error, "Topic",
-        "Message contained invalid floating point values (nans or infs)");
-    }
+    setStatus(
+      rviz_common::properties::StatusProperty::Error, "Topic",
+      "Message contained invalid floating point values (nans or infs)");
     return;
   }
 
@@ -244,12 +268,14 @@ void CAMDisplay::processMessage(const std::variant<
   if (it != cams_.end()) it->second = cam; // Key exists, update the value
   else cams_.insert(std::make_pair(cam.getStationID(), cam));
 
-  // Update CAM TS message counter and status shown in RViz
-  if (cam.isTS()) {
-    ++received_ts_;
-    setStatus(
-      rviz_common::properties::StatusProperty::Ok, "CAM TS Topic", QString::number(received_ts_) + " messages received");
-  }
+  ++messages_received_;
+  QString topic_str = QString::number(messages_received_) + " messages received";
+  // Append topic subscription frequency.
+  const double duration = (rviz_node_->now() - subscription_start_time_).seconds();
+  const double subscription_frequency = static_cast<double>(messages_received_) / duration;
+  topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
+  setStatus(
+    rviz_common::properties::StatusProperty::Ok, "Topic", topic_str);
 
   return;
 }
@@ -258,9 +284,7 @@ void CAMDisplay::update(float, float)
 {
   // Check for outdated CAMs
   for (auto it = cams_.begin(); it != cams_.end(); ) {
-    CAMRenderObject & obj = it->second;
-    double timeout = obj.isTS() ? buffer_timeout_ts_->getFloat() : buffer_timeout_->getFloat();
-    if (obj.getAge(rviz_node_->now()) > timeout) {
+    if (it->second.getAge(rviz_node_->now()) > buffer_timeout_->getFloat()) {
       it = cams_.erase(it);
     }
     else {
@@ -274,11 +298,6 @@ void CAMDisplay::update(float, float)
   for(auto it = cams_.begin(); it != cams_.end(); ++it) {
 
     CAMRenderObject cam = it->second;
-
-    // Skip rendering depending on the visualize checkboxes
-    if (cam.isTS() && !viz_cam_ts_->getBool()) continue;
-    if (!cam.isTS() && !viz_cam_->getBool()) continue;
-
     Ogre::Vector3 sn_position;
     Ogre::Quaternion sn_orientation;
     if (!context_->getFrameManager()->getTransform(cam.getHeader(), sn_position, sn_orientation)) {
@@ -345,34 +364,34 @@ void CAMDisplay::update(float, float)
 
     // set the dimensions of bounding box
     Ogre::Vector3 dims;
-    double scale = cam.isTS() ? bb_scale_ts_->getFloat() : bb_scale_->getFloat();
+    double scale = bb_scale_->getFloat();
     dims.x = dimensions.x*scale;
     dims.y = dimensions.y*scale;
     dims.z = dimensions.z*scale;
     bbox->setScale(dims);
     // set the color of bounding box
-    Ogre::ColourValue bb_color = rviz_common::properties::qtToOgre((cam.isTS() ? color_property_ts_->getColor() : color_property_->getColor()));
+    Ogre::ColourValue bb_color = rviz_common::properties::qtToOgre(color_property_->getColor());
     bbox->setColor(bb_color);
     bboxs_.push_back(bbox);
 
     // Visualize meta-information as text
-    if((cam.isTS() ? show_meta_ts_->getBool() : show_meta_->getBool())) {
+    if(show_meta_->getBool()) {
       std::string text;
-      if((cam.isTS() ? show_station_id_ts_->getBool() : show_station_id_->getBool())) {
+      if(show_station_id_->getBool()) {
         text+="StationID: " + std::to_string(cam.getStationID());
         text+="\n";
       }
-      if((cam.isTS() ? show_speed_ts_->getBool() : show_speed_->getBool())) {
+      if(show_speed_->getBool()) {
         text+="Speed: " + std::to_string((int)(cam.getSpeed()*3.6)) + " km/h";
       }
-      if(!text.size()) continue; // skip adding empty text
-      std::shared_ptr<rviz_rendering::MovableText> text_render = std::make_shared<rviz_rendering::MovableText>(text, "Liberation Sans", (cam.isTS() ? char_height_ts_->getFloat() : char_height_->getFloat()));
+      if(!text.size()) return;
+      std::shared_ptr<rviz_rendering::MovableText> text_render = std::make_shared<rviz_rendering::MovableText>(text, "Liberation Sans", char_height_->getFloat());
       double height = dims.z;
       height+=text_render->getBoundingRadius();
       Ogre::Vector3 offs(0.0, 0.0, height);
       // There is a bug in rviz_rendering::MovableText::setGlobalTranslation https://github.com/ros2/rviz/issues/974
       text_render->setGlobalTranslation(offs);
-      Ogre::ColourValue text_color = rviz_common::properties::qtToOgre((cam.isTS() ? text_color_property_ts_->getColor() : text_color_property_->getColor()));
+      Ogre::ColourValue text_color = rviz_common::properties::qtToOgre(text_color_property_->getColor());
       text_render->setColor(text_color);
       child_scene_node->attachObject(text_render.get());
       texts_.push_back(text_render);

--- a/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
@@ -111,7 +111,6 @@ void CAMDisplay::setTopic(const QString & topic, const QString & datatype)
 
 void CAMDisplay::updateTopic()
 {
-  std::cout << "CAMDisplay::updateTopic()" << std::endl;
   unsubscribe();
   reset();
   subscribe();
@@ -239,7 +238,7 @@ void CAMDisplay::onDisable()
   reset();
 }
 
-// Unified handler used by both release 1 (base-class override delegates to this) and release 2 subscription lambda
+// Unified handler used by both release 1 and release 2
 void CAMDisplay::processMessage(const std::variant<
     etsi_its_cam_msgs::msg::CAM,
     etsi_its_cam_ts_msgs::msg::CAM
@@ -269,13 +268,8 @@ void CAMDisplay::processMessage(const std::variant<
   else cams_.insert(std::make_pair(cam.getStationID(), cam));
 
   ++messages_received_;
-  QString topic_str = QString::number(messages_received_) + " messages received";
-  // Append topic subscription frequency.
-  const double duration = (rviz_node_->now() - subscription_start_time_).seconds();
-  const double subscription_frequency = static_cast<double>(messages_received_) / duration;
-  topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
   setStatus(
-    rviz_common::properties::StatusProperty::Ok, "Topic", topic_str);
+    rviz_common::properties::StatusProperty::Ok, "Topic", QString::number(messages_received_) + " messages received");
 
   return;
 }

--- a/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/CAM/cam_display.cpp
@@ -38,6 +38,8 @@ SOFTWARE.
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/float_property.hpp"
 #include "rviz_common/properties/bool_property.hpp"
+#include "rviz_common/properties/ros_topic_property.hpp"
+#include "rviz_common/properties/qos_profile_property.hpp"
 
 #include "rviz_common/properties/parse_color.hpp"
 
@@ -48,20 +50,22 @@ namespace displays
 
 CAMDisplay::CAMDisplay()
 {
-  // General Properties
+  // CAM (release 1) properties
+  viz_cam_ = new rviz_common::properties::BoolProperty("Visualize CAMs", true,
+    "Show CAM (release 1) messages", this, SLOT(changedCAMViz()));
   buffer_timeout_ = new rviz_common::properties::FloatProperty(
     "Timeout", 0.1f,
-    "Time (in s) until objects disappear", this);
+    "Time (in s) until objects disappear", viz_cam_);
   buffer_timeout_->setMin(0);
   bb_scale_ = new rviz_common::properties::FloatProperty(
     "Scale", 1.0f,
-    "Scale of objects", this);
+    "Scale of objects", viz_cam_);
   bb_scale_->setMin(0.01);
   color_property_ = new rviz_common::properties::ColorProperty(
     "Color", QColor(25, 0, 255),
-    "Object color", this);
+    "Object color", viz_cam_);
   show_meta_ = new rviz_common::properties::BoolProperty("Metadata", true,
-    "Show metadata as text next to objects", this);
+    "Show metadata as text next to objects", viz_cam_);
   text_color_property_ = new rviz_common::properties::ColorProperty(
     "Color", QColor(25, 0, 255),
     "Text color", show_meta_);
@@ -71,6 +75,35 @@ CAMDisplay::CAMDisplay()
   show_speed_ = new rviz_common::properties::BoolProperty("Speed", true,
     "Show speed", show_meta_);
 
+  // CAM TS (release 2) properties
+  cam_ts_topic_property_ = new rviz_common::properties::RosTopicProperty(
+    "CAM TS Topic", "/etsi_its_conversion/cam_ts/out",
+    rosidl_generator_traits::data_type<etsi_its_cam_ts_msgs::msg::CAM>(),
+    "Topic of CAM TS (release 2) messages", this, SLOT(changedCAMTSTopic()));
+  cam_ts_qos_property_ = new rviz_common::properties::QosProfileProperty(cam_ts_topic_property_, cam_ts_qos_profile_);
+  viz_cam_ts_ = new rviz_common::properties::BoolProperty("Visualize CAMs TS", false,
+    "Show CAM TS (release 2) messages", this, SLOT(changedCAMTSViz()));
+  buffer_timeout_ts_ = new rviz_common::properties::FloatProperty(
+    "Timeout", 0.1f,
+    "Time (in s) until objects disappear", viz_cam_ts_);
+  buffer_timeout_ts_->setMin(0);
+  bb_scale_ts_ = new rviz_common::properties::FloatProperty(
+    "Scale", 1.0f,
+    "Scale of objects", viz_cam_ts_);
+  bb_scale_ts_->setMin(0.01);
+  color_property_ts_ = new rviz_common::properties::ColorProperty(
+    "Color", QColor(25, 0, 255),
+    "Object color", viz_cam_ts_);
+  show_meta_ts_ = new rviz_common::properties::BoolProperty("Metadata", true,
+    "Show metadata as text next to objects", viz_cam_ts_);
+  text_color_property_ts_ = new rviz_common::properties::ColorProperty(
+    "Color", QColor(25, 0, 255),
+    "Text color", show_meta_ts_);
+  char_height_ts_ = new rviz_common::properties::FloatProperty("Scale", 4.0, "Scale of text", show_meta_ts_);
+  show_station_id_ts_ = new rviz_common::properties::BoolProperty("StationID", true,
+    "Show StationID", show_meta_ts_);
+  show_speed_ts_ = new rviz_common::properties::BoolProperty("Speed", true,
+    "Show speed", show_meta_ts_);
 }
 
 CAMDisplay::~CAMDisplay()
@@ -87,6 +120,14 @@ void CAMDisplay::onInitialize()
   auto nodeAbstraction = context_->getRosNodeAbstraction().lock();
   rviz_node_ = nodeAbstraction->get_raw_node();
 
+  // Initialize topic and QoS properties for CAM TS
+  cam_ts_topic_property_->initialize(nodeAbstraction);
+  cam_ts_qos_property_->initialize(
+      [this](rclcpp::QoS profile) {
+        cam_ts_qos_profile_ = profile;
+        changedCAMTSTopic();
+      });
+
   manual_object_ = scene_manager_->createManualObject();
   manual_object_->setDynamic(true);
   scene_node_->attachObject(manual_object_);
@@ -96,9 +137,82 @@ void CAMDisplay::reset()
 {
   RTDClass::reset();
   manual_object_->clear();
+  cam_ts_sub_.reset();
 }
 
+void CAMDisplay::changedCAMViz() {
+  if(!viz_cam_->getBool()) {
+    deleteStatus("Topic");
+  }
+}
+
+void CAMDisplay::changedCAMTSViz() {
+  if(!viz_cam_ts_->getBool()) {
+    deleteStatus("CAM TS Topic");
+    cam_ts_sub_.reset();
+  } 
+  else changedCAMTSTopic();
+}
+
+void CAMDisplay::changedCAMTSTopic() {
+  cam_ts_sub_.reset();
+  received_ts_ = 0;
+  if(cam_ts_topic_property_->isEmpty()) {
+    setStatus(
+        rviz_common::properties::StatusProperty::Warn,
+        "CAM TS Topic",
+        QString("Error subscribing: Empty topic name"));
+      return;
+  }
+
+  std::map<std::string, std::vector<std::string>> published_topics = rviz_node_->get_topic_names_and_types();
+  bool topic_available = false;
+  std::string topic_message_type;
+  for (const auto & topic : published_topics) {
+    // Only add topics whose type matches.
+    if(topic.first == cam_ts_topic_property_->getTopicStd()) {
+      topic_available = true;
+      for (const auto & type : topic.second) {
+        topic_message_type = type;
+        if (type == "etsi_its_cam_ts_msgs/msg/CAM") {
+          cam_ts_sub_ = rviz_node_->create_subscription<etsi_its_cam_ts_msgs::msg::CAM>(
+            cam_ts_topic_property_->getTopicStd(),
+            cam_ts_qos_profile_,
+            [this](const etsi_its_cam_ts_msgs::msg::CAM::SharedPtr msg) {
+              // Forward release 2 message to unified handler
+              this->processMessage(std::variant<etsi_its_cam_msgs::msg::CAM, etsi_its_cam_ts_msgs::msg::CAM>(*msg));
+            });
+          return;
+        }
+      }
+    }
+  }
+  if(!topic_available) {
+    setStatus(
+      rviz_common::properties::StatusProperty::Warn, "CAM TS Topic",
+      QString("Error subscribing to ") + QString::fromStdString(cam_ts_topic_property_->getTopicStd())
+      + QString(": Topic is not available!"));
+  }
+  else {
+    setStatus(
+      rviz_common::properties::StatusProperty::Warn, "CAM TS Topic",
+      QString("Error subscribing to ") + QString::fromStdString(cam_ts_topic_property_->getTopicStd())
+      + QString(": Message type ") + QString::fromStdString(topic_message_type) + QString::fromStdString(" does not equal etsi_its_cam_ts_msgs::msg::CAM!"));
+  }
+
+}
+
+// Base-class override but delegate to the unified handler
 void CAMDisplay::processMessage(etsi_its_cam_msgs::msg::CAM::ConstSharedPtr msg)
+{
+  processMessage(std::variant<etsi_its_cam_msgs::msg::CAM, etsi_its_cam_ts_msgs::msg::CAM>(*msg));
+}
+
+// Unified handler used by both release 1 (base-class override delegates to this) and release 2 subscription lambda
+void CAMDisplay::processMessage(const std::variant<
+    etsi_its_cam_msgs::msg::CAM,
+    etsi_its_cam_ts_msgs::msg::CAM
+  > & msg_variant)
 {
   // Generate CAM render object from message
   rclcpp::Time now = rviz_node_->now();
@@ -110,11 +224,18 @@ void CAMDisplay::processMessage(etsi_its_cam_msgs::msg::CAM::ConstSharedPtr msg)
     return;
   }
 
-  CAMRenderObject cam(*msg, now, getLeapSecondInsertionsSince2004(static_cast<uint64_t>(now.seconds())));
+  CAMRenderObject cam(msg_variant, now, getLeapSecondInsertionsSince2004(static_cast<uint64_t>(now.seconds())));
   if (!cam.validateFloats()) {
-    setStatus(
-      rviz_common::properties::StatusProperty::Error, "Topic",
-      "Message contained invalid floating point values (nans or infs)");
+    // report error on the proper status entry depending on origin
+    if (cam.isTS()) {
+      setStatus(
+        rviz_common::properties::StatusProperty::Error, "CAM TS Topic",
+        "Message contained invalid floating point values (nans or infs)");
+    } else {
+      setStatus(
+        rviz_common::properties::StatusProperty::Error, "Topic",
+        "Message contained invalid floating point values (nans or infs)");
+    }
     return;
   }
 
@@ -123,6 +244,13 @@ void CAMDisplay::processMessage(etsi_its_cam_msgs::msg::CAM::ConstSharedPtr msg)
   if (it != cams_.end()) it->second = cam; // Key exists, update the value
   else cams_.insert(std::make_pair(cam.getStationID(), cam));
 
+  // Update CAM TS message counter and status shown in RViz
+  if (cam.isTS()) {
+    ++received_ts_;
+    setStatus(
+      rviz_common::properties::StatusProperty::Ok, "CAM TS Topic", QString::number(received_ts_) + " messages received");
+  }
+
   return;
 }
 
@@ -130,7 +258,9 @@ void CAMDisplay::update(float, float)
 {
   // Check for outdated CAMs
   for (auto it = cams_.begin(); it != cams_.end(); ) {
-    if (it->second.getAge(rviz_node_->now()) > buffer_timeout_->getFloat()) {
+    CAMRenderObject & obj = it->second;
+    double timeout = obj.isTS() ? buffer_timeout_ts_->getFloat() : buffer_timeout_->getFloat();
+    if (obj.getAge(rviz_node_->now()) > timeout) {
       it = cams_.erase(it);
     }
     else {
@@ -144,6 +274,11 @@ void CAMDisplay::update(float, float)
   for(auto it = cams_.begin(); it != cams_.end(); ++it) {
 
     CAMRenderObject cam = it->second;
+
+    // Skip rendering depending on the visualize checkboxes
+    if (cam.isTS() && !viz_cam_ts_->getBool()) continue;
+    if (!cam.isTS() && !viz_cam_->getBool()) continue;
+
     Ogre::Vector3 sn_position;
     Ogre::Quaternion sn_orientation;
     if (!context_->getFrameManager()->getTransform(cam.getHeader(), sn_position, sn_orientation)) {
@@ -210,34 +345,34 @@ void CAMDisplay::update(float, float)
 
     // set the dimensions of bounding box
     Ogre::Vector3 dims;
-    double scale = bb_scale_->getFloat();
+    double scale = cam.isTS() ? bb_scale_ts_->getFloat() : bb_scale_->getFloat();
     dims.x = dimensions.x*scale;
     dims.y = dimensions.y*scale;
     dims.z = dimensions.z*scale;
     bbox->setScale(dims);
     // set the color of bounding box
-    Ogre::ColourValue bb_color = rviz_common::properties::qtToOgre(color_property_->getColor());
+    Ogre::ColourValue bb_color = rviz_common::properties::qtToOgre((cam.isTS() ? color_property_ts_->getColor() : color_property_->getColor()));
     bbox->setColor(bb_color);
     bboxs_.push_back(bbox);
 
     // Visualize meta-information as text
-    if(show_meta_->getBool()) {
+    if((cam.isTS() ? show_meta_ts_->getBool() : show_meta_->getBool())) {
       std::string text;
-      if(show_station_id_->getBool()) {
+      if((cam.isTS() ? show_station_id_ts_->getBool() : show_station_id_->getBool())) {
         text+="StationID: " + std::to_string(cam.getStationID());
         text+="\n";
       }
-      if(show_speed_->getBool()) {
+      if((cam.isTS() ? show_speed_ts_->getBool() : show_speed_->getBool())) {
         text+="Speed: " + std::to_string((int)(cam.getSpeed()*3.6)) + " km/h";
       }
-      if(!text.size()) return;
-      std::shared_ptr<rviz_rendering::MovableText> text_render = std::make_shared<rviz_rendering::MovableText>(text, "Liberation Sans", char_height_->getFloat());
+      if(!text.size()) continue; // skip adding empty text
+      std::shared_ptr<rviz_rendering::MovableText> text_render = std::make_shared<rviz_rendering::MovableText>(text, "Liberation Sans", (cam.isTS() ? char_height_ts_->getFloat() : char_height_->getFloat()));
       double height = dims.z;
       height+=text_render->getBoundingRadius();
       Ogre::Vector3 offs(0.0, 0.0, height);
       // There is a bug in rviz_rendering::MovableText::setGlobalTranslation https://github.com/ros2/rviz/issues/974
       text_render->setGlobalTranslation(offs);
-      Ogre::ColourValue text_color = rviz_common::properties::qtToOgre(text_color_property_->getColor());
+      Ogre::ColourValue text_color = rviz_common::properties::qtToOgre((cam.isTS() ? text_color_property_ts_->getColor() : text_color_property_->getColor()));
       text_render->setColor(text_color);
       child_scene_node->attachObject(text_render.get());
       texts_.push_back(text_render);

--- a/etsi_its_rviz_plugins/src/displays/CAM/cam_render_object.cpp
+++ b/etsi_its_rviz_plugins/src/displays/CAM/cam_render_object.cpp
@@ -23,37 +23,79 @@ SOFTWARE.
 ============================================================================= */
 
 #include "displays/CAM/cam_render_object.hpp"
+#include <variant>
+#include <type_traits>
+#include <cmath>
 
 namespace etsi_its_msgs
 {
 namespace displays
 {
 
-  CAMRenderObject::CAMRenderObject(etsi_its_cam_msgs::msg::CAM cam, rclcpp::Time receive_time, uint16_t n_leap_seconds) {
-
+  CAMRenderObject::CAMRenderObject(const std::variant<
+      etsi_its_cam_msgs::msg::CAM,
+      etsi_its_cam_ts_msgs::msg::CAM
+    > & cam_variant, rclcpp::Time receive_time, uint16_t n_leap_seconds)
+  {
     int zone;
     bool northp;
-    geometry_msgs::msg::PointStamped p = etsi_its_cam_msgs::access::getUTMPosition(cam, zone, northp);
+    geometry_msgs::msg::PointStamped p;
+    uint64_t nanosecs = 0;
+    uint32_t station_id_val = 0;
+    int station_type_val = 0;
+    double heading_deg = 0.0;
+    double vehicle_length = 0.0;
+    double vehicle_width = 0.0;
+    double vehicle_speed = 0.0;
+
+    if (const auto * r1 = std::get_if<etsi_its_cam_msgs::msg::CAM>(&cam_variant)) {
+      is_ts = false;
+      p = etsi_its_cam_msgs::access::getUTMPosition(*r1, zone, northp);
+      nanosecs = etsi_its_cam_msgs::access::getUnixNanosecondsFromGenerationDeltaTime(etsi_its_cam_msgs::access::getGenerationDeltaTime(*r1), receive_time.nanoseconds(), n_leap_seconds);
+      station_id_val = etsi_its_cam_msgs::access::getStationID(*r1);
+      station_type_val = etsi_its_cam_msgs::access::getStationType(*r1);
+      heading_deg = etsi_its_cam_msgs::access::getHeading(*r1);
+      vehicle_length = etsi_its_cam_msgs::access::getVehicleLength(*r1);
+      vehicle_width = etsi_its_cam_msgs::access::getVehicleWidth(*r1);
+      vehicle_speed = etsi_its_cam_msgs::access::getSpeed(*r1);
+    }
+    else if (const auto * r2 = std::get_if<etsi_its_cam_ts_msgs::msg::CAM>(&cam_variant)) {
+      is_ts = true;
+      p = etsi_its_cam_ts_msgs::access::getUTMPosition(*r2, zone, northp);
+      nanosecs = etsi_its_cam_ts_msgs::access::getUnixNanosecondsFromGenerationDeltaTime(etsi_its_cam_ts_msgs::access::getGenerationDeltaTime(*r2), receive_time.nanoseconds(), n_leap_seconds);
+      station_id_val = etsi_its_cam_ts_msgs::access::getStationID(*r2);
+      station_type_val = etsi_its_cam_ts_msgs::access::getStationType(*r2);
+      heading_deg = etsi_its_cam_ts_msgs::access::getHeading(*r2);
+      vehicle_length = etsi_its_cam_ts_msgs::access::getVehicleLength(*r2);
+      vehicle_width = etsi_its_cam_ts_msgs::access::getVehicleWidth(*r2);
+      vehicle_speed = etsi_its_cam_ts_msgs::access::getSpeed(*r2);
+    } else { // unexpected variant content (minimal safe initialization)
+      is_ts = false;
+      header.frame_id = "";
+      header.stamp = rclcpp::Time(0);
+      station_id = 0;
+      station_type = 0;
+      pose = geometry_msgs::msg::Pose();
+      dimensions = geometry_msgs::msg::Vector3();
+      speed = 0.0;
+      return;
+    }
+
+    // common initialization
     header.frame_id = p.header.frame_id;
-
-    uint64_t nanosecs = etsi_its_cam_msgs::access::getUnixNanosecondsFromGenerationDeltaTime(etsi_its_cam_msgs::access::getGenerationDeltaTime(cam), receive_time.nanoseconds(), n_leap_seconds);
     header.stamp = rclcpp::Time(nanosecs);
-
-    station_id = etsi_its_cam_msgs::access::getStationID(cam);
-    station_type = etsi_its_cam_msgs::access::getStationType(cam);
-
-    double heading = (90-etsi_its_cam_msgs::access::getHeading(cam))*M_PI/180.0; // 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West
-    while(heading<0) heading+=2*M_PI;
+    station_id = station_id_val;
+    station_type = station_type_val;
+    double heading = (90.0 - heading_deg) * M_PI / 180.0;
+    while (heading < 0) heading += 2 * M_PI;
     pose.position = p.point;
     tf2::Quaternion orientation;
     orientation.setRPY(0.0, 0.0, heading);
     pose.orientation = tf2::toMsg(orientation);
-
-    dimensions.x = etsi_its_cam_msgs::access::getVehicleLength(cam);
-    dimensions.y = etsi_its_cam_msgs::access::getVehicleWidth(cam);
+    dimensions.x = vehicle_length;
+    dimensions.y = vehicle_width;
     dimensions.z = 1.6;
-
-    speed = etsi_its_cam_msgs::access::getSpeed(cam);
+    speed = vehicle_speed;
   }
 
   bool CAMRenderObject::validateFloats() {
@@ -85,7 +127,6 @@ namespace displays
   }
 
   geometry_msgs::msg::Vector3 CAMRenderObject::getDimensions() {
-
     return dimensions;
   }
 
@@ -93,5 +134,8 @@ namespace displays
     return speed;
   }
 
+  bool CAMRenderObject::isTS() {
+    return is_ts;
+  }
 }  // namespace displays
 }  // namespace etsi_its_msgs


### PR DESCRIPTION
Hi, following the discussion in #103, this PR introduces a CAM display implementation capable of subscribing to both CAM (release 1) and CAM TS (release 2) messages, as suggested by @lreiher.