### PR TITLE
add support for DENM TS messages in RViz plugins

### DIFF
--- a/etsi_its_rviz_plugins/CMakeLists.txt
+++ b/etsi_its_rviz_plugins/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(etsi_its_cam_msgs REQUIRED)
 find_package(etsi_its_cam_ts_msgs REQUIRED)
 find_package(etsi_its_cpm_ts_msgs REQUIRED)
 find_package(etsi_its_denm_msgs REQUIRED)
+find_package(etsi_its_denm_ts_msgs REQUIRED)
 find_package(etsi_its_mapem_ts_msgs REQUIRED)
 find_package(etsi_its_spatem_ts_msgs REQUIRED)
 find_package(etsi_its_msgs_utils REQUIRED)
@@ -72,6 +73,7 @@ ament_target_dependencies(${PROJECT_NAME}
   etsi_its_cam_ts_msgs
   etsi_its_cpm_ts_msgs
   etsi_its_denm_msgs
+  etsi_its_denm_ts_msgs
   etsi_its_mapem_ts_msgs
   etsi_its_spatem_ts_msgs
   etsi_its_msgs_utils
@@ -90,6 +92,7 @@ ament_export_dependencies(
   etsi_its_cam_ts_msgs
   etsi_its_cpm_ts_msgs
   etsi_its_denm_msgs
+  etsi_its_denm_ts_msgs
   etsi_its_mapem_ts_msgs
   etsi_its_spatem_ts_msgs
   etsi_its_msgs_utils

--- a/etsi_its_rviz_plugins/include/displays/DENM/denm_display.hpp
+++ b/etsi_its_rviz_plugins/include/displays/DENM/denm_display.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "etsi_its_denm_msgs/msg/denm.hpp"
+#include "etsi_its_denm_ts_msgs/msg/denm.hpp"
 
 #include "displays/DENM/denm_render_object.hpp"
 #include "displays/DENM/overlay_object.hpp"
@@ -35,10 +36,9 @@ namespace displays
 
 /**
  * @class DENMDisplay
- * @brief Displays an etsi_its_denm_msgs::DENM
+ * @brief Displays an etsi_its_denm_msgs::DENM or an etsi_its_denm_ts_msgs::DENM
  */
-class DENMDisplay : public
-  rviz_common::RosTopicDisplay<etsi_its_denm_msgs::msg::DENM>
+class DENMDisplay : public rviz_common::_RosTopicDisplay
 {
   Q_OBJECT
 
@@ -50,8 +50,32 @@ public:
 
   void reset() override;
 
+  void setTopic(const QString & topic, const QString & datatype) override;
+
+protected Q_SLOTS:
+  void updateTopic() override;
+
 protected:
-  void processMessage(etsi_its_denm_msgs::msg::DENM::ConstSharedPtr msg) override;
+  // DENM type detection
+  enum class DenmType
+  {
+    NONE,
+    RELEASE_1,
+    RELEASE_2
+  };
+  DenmType detectDenmType(const std::string & topic);
+
+  void subscribe();
+  void unsubscribe();
+  void onEnable() override;
+  void onDisable() override;
+
+  // Unified handler that accepts either DENM (release 1) or DENM TS (release 2)
+  void processMessage(const std::variant<
+      etsi_its_denm_msgs::msg::DENM,
+      etsi_its_denm_ts_msgs::msg::DENM
+    > & msg_variant);
+
   void update(float wall_dt, float ros_dt) override;
   void updateOverlay(DENMRenderObject &denm_render_object);
 
@@ -59,6 +83,12 @@ private:
   Ogre::ManualObject * manual_object_;
 
   rclcpp::Node::SharedPtr rviz_node_;
+  std::shared_ptr<rclcpp::SubscriptionBase> subscription_;
+  rclcpp::TimerBase::SharedPtr topic_check_timer_;
+
+  DenmType active_denm_type_;
+  rclcpp::Time subscription_start_time_;
+  uint32_t messages_received_;
 
   // Properties
   rviz_common::properties::BoolProperty *show_meta_, *show_station_id_, *show_cause_code_, *show_sub_cause_code_;

--- a/etsi_its_rviz_plugins/include/displays/DENM/denm_render_object.hpp
+++ b/etsi_its_rviz_plugins/include/displays/DENM/denm_render_object.hpp
@@ -1,4 +1,5 @@
 #include "etsi_its_denm_msgs/msg/denm.hpp"
+#include "etsi_its_denm_ts_msgs/msg/denm.hpp"
 
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
@@ -7,8 +8,11 @@
 
 #include <tf2/LinearMath/Quaternion.h>
 #include <etsi_its_msgs_utils/denm_access.hpp>
+#include <etsi_its_msgs_utils/denm_ts_access.hpp>
 
 #include "rviz_common/validate_floats.hpp"
+#include <variant>
+#include <cmath>
 
 namespace etsi_its_msgs
 {
@@ -22,7 +26,16 @@ namespace displays
 class DENMRenderObject
 {
   public:
-    DENMRenderObject(etsi_its_denm_msgs::msg::DENM denm);
+    DENMRenderObject(const std::variant<
+        etsi_its_denm_msgs::msg::DENM,
+        etsi_its_denm_ts_msgs::msg::DENM
+      > & denm_variant);
+
+    DENMRenderObject(const etsi_its_denm_msgs::msg::DENM & denm)
+      : DENMRenderObject(std::variant<etsi_its_denm_msgs::msg::DENM, etsi_its_denm_ts_msgs::msg::DENM>(denm)) {}
+      
+    DENMRenderObject(const etsi_its_denm_ts_msgs::msg::DENM & denm)
+      : DENMRenderObject(std::variant<etsi_its_denm_msgs::msg::DENM, etsi_its_denm_ts_msgs::msg::DENM>(denm)) {}
 
     /**
      * @brief This function validates all float variables that are part of a DENMRenderObject
@@ -93,6 +106,14 @@ class DENMRenderObject
      * @return std::string
      */
     std::string getSubCauseCode();
+
+    /**
+     * @brief Check if the DENM object is TS (release 2)
+     *
+     * @return true if DENM object is TS, false otherwise
+     */
+    bool isTS();
+
   private:
     // member variables
     std_msgs::msg::Header header;
@@ -103,7 +124,7 @@ class DENMRenderObject
     geometry_msgs::msg::Pose pose;
     geometry_msgs::msg::Vector3 dimensions;
     double speed;
-
+    bool is_ts = false;
 };
 
 }  // namespace displays

--- a/etsi_its_rviz_plugins/package.xml
+++ b/etsi_its_rviz_plugins/package.xml
@@ -25,6 +25,7 @@
   <depend>etsi_its_cam_ts_msgs</depend>
   <depend>etsi_its_cpm_ts_msgs</depend>
   <depend>etsi_its_denm_msgs</depend>
+  <depend>etsi_its_denm_ts_msgs</depend>
   <depend>etsi_its_mapem_ts_msgs</depend>
   <depend>etsi_its_spatem_ts_msgs</depend>
   <depend>etsi_its_msgs_utils</depend>

--- a/etsi_its_rviz_plugins/plugins_description.xml
+++ b/etsi_its_rviz_plugins/plugins_description.xml
@@ -19,9 +19,10 @@
     base_class_type="rviz_common::Display"
   >
     <description>
-      Displays data from a etsi_its_denm_msgs::DENM.
+      Displays data from a etsi_its_denm_msgs::DENM or a etsi_its_denm_ts_msgs::DENM.
     </description>
     <message_type>etsi_its_denm_msgs/msg/DENM</message_type>
+    <message_type>etsi_its_denm_ts_msgs/msg/DENM</message_type>
   </class>
 
   <class

--- a/etsi_its_rviz_plugins/src/displays/DENM/denm_display.cpp
+++ b/etsi_its_rviz_plugins/src/displays/DENM/denm_display.cpp
@@ -28,6 +28,8 @@ namespace displays
 {
 
 DENMDisplay::DENMDisplay()
+  : active_denm_type_(DenmType::NONE),
+    messages_received_(0)
 {
   // General Properties
   buffer_timeout_ = new rviz_common::properties::FloatProperty(
@@ -68,6 +70,8 @@ DENMDisplay::DENMDisplay()
   static int idx = 0;
   overlay_.reset(new rviz_plugin::OverlayObject("Ogre Overlay number " + std::to_string(idx)));
   idx++;
+
+  topic_property_->setDescription("etsi_its_denm_msgs/msg/DENM or etsi_its_denm_ts_msgs/msg/DENM topic to subscribe to.");
 }
 
 DENMDisplay::~DENMDisplay()
@@ -79,7 +83,7 @@ DENMDisplay::~DENMDisplay()
 
 void DENMDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  rviz_common::_RosTopicDisplay::onInitialize();
 
   rviz_rendering::RenderSystem::get()->prepareOverlays(scene_manager_);
 
@@ -93,16 +97,156 @@ void DENMDisplay::onInitialize()
 
 void DENMDisplay::reset()
 {
-  RTDClass::reset();
+  Display::reset();
   manual_object_->clear();
   denms_.clear();
   overlay_->hide();
+  messages_received_ = 0;
 }
 
-void DENMDisplay::processMessage(etsi_its_denm_msgs::msg::DENM::ConstSharedPtr msg)
+void DENMDisplay::setTopic(const QString & topic, const QString & datatype)
+{
+  (void) datatype;
+  topic_property_->setString(topic);
+}
+
+void DENMDisplay::updateTopic()
+{
+  unsubscribe();
+  reset();
+  subscribe();
+  context_->queueRender();
+}
+
+DENMDisplay::DenmType DENMDisplay::detectDenmType(const std::string & topic)
+{
+  auto topics = rviz_node_->get_topic_names_and_types();
+
+  auto it = topics.find(topic);
+  if (it == topics.end()) {
+    return DenmType::NONE;
+  }
+
+  for (const auto & type : it->second) {
+    if (type == "etsi_its_denm_ts_msgs/msg/DENM") {
+      return DenmType::RELEASE_2;
+    }
+    if (type == "etsi_its_denm_msgs/msg/DENM") {
+      return DenmType::RELEASE_1;
+    }
+  }
+
+  return DenmType::NONE;
+}
+
+void DENMDisplay::subscribe()
+{
+  if (!isEnabled() ) {
+    return;
+  }
+
+  unsubscribe();
+
+  if (topic_property_->isEmpty()) {
+    setStatus(
+      rviz_common::properties::StatusProperty::Error,
+      "Topic",
+      QString("Error subscribing: Empty topic name"));
+    return;
+  }
+
+  const std::string topic = topic_property_->getTopicStd();
+
+  // Validate topic name
+  try {
+    rclcpp::expand_topic_or_service_name(
+      topic,
+      rviz_node_->get_name(),
+      rviz_node_->get_namespace());
+  } catch (const rclcpp::exceptions::InvalidTopicNameError & e) {
+    setStatus(
+      rviz_common::properties::StatusProperty::Error,
+      "Topic",
+      QString("Error subscribing: ") + e.what());
+    return;
+  }
+
+  DenmType denm_type = detectDenmType(topic);
+
+  if (denm_type == DenmType::RELEASE_1) {
+    subscription_ = rviz_node_->create_subscription<etsi_its_denm_msgs::msg::DENM>(
+      topic,
+      qos_profile,
+      [this](etsi_its_denm_msgs::msg::DENM::SharedPtr msg) {
+        processMessage(std::variant<etsi_its_denm_msgs::msg::DENM,etsi_its_denm_ts_msgs::msg::DENM>(*msg));
+      });
+    active_denm_type_ = DenmType::RELEASE_1;
+  }
+  else if (denm_type == DenmType::RELEASE_2) {
+    subscription_ = rviz_node_->create_subscription<etsi_its_denm_ts_msgs::msg::DENM>(
+      topic,
+      qos_profile,
+      [this](etsi_its_denm_ts_msgs::msg::DENM::ConstSharedPtr msg) {
+        this->processMessage(std::variant<etsi_its_denm_msgs::msg::DENM,etsi_its_denm_ts_msgs::msg::DENM>(*msg));
+      });
+    active_denm_type_ = DenmType::RELEASE_2;
+  }
+  else { // denm_type == DenmType::NONE, i.e. not found or wrong type
+    setStatus(
+      rviz_common::properties::StatusProperty::Warn, "Topic",
+      QString("Waiting for topic: ") + QString::fromStdString(topic)
+      + QString(" (etsi_its_denm_msgs/msg/DENM or etsi_its_denm_ts_msgs/msg/DENM)"));
+    
+    // Start periodic timer to check for topic availability
+    if (!topic_check_timer_) {
+      topic_check_timer_ = rviz_node_->create_wall_timer(
+        std::chrono::milliseconds(1000),
+        [this]() { subscribe(); });
+    }
+  }
+
+  if (subscription_) {
+    subscription_start_time_ = rviz_node_->now();
+    setStatus(rviz_common::properties::StatusProperty::Ok, "Topic", "OK");
+    // Cancel timer since the subscription was successful
+    if (topic_check_timer_) {
+      topic_check_timer_->cancel();
+      topic_check_timer_.reset();
+    }
+  }
+}
+
+void DENMDisplay::unsubscribe()
+{
+  subscription_.reset();
+  active_denm_type_ = DenmType::NONE;
+
+  // Cancel the timer
+  if (topic_check_timer_) {
+    topic_check_timer_->cancel();
+    topic_check_timer_.reset();
+  }
+}
+
+void DENMDisplay::onEnable()
+{
+  subscribe();
+}
+
+void DENMDisplay::onDisable()
+{
+  unsubscribe();
+  reset();
+}
+
+// Unified handler used by both release 1 and release 2
+void DENMDisplay::processMessage(const std::variant<
+    etsi_its_denm_msgs::msg::DENM,
+    etsi_its_denm_ts_msgs::msg::DENM
+  > & msg_variant)
 {
   // Generate DENM render object from message
-  DENMRenderObject denm(*msg);
+  DENMRenderObject denm(msg_variant);
   if (!denm.validateFloats()) {
         setStatus(
           rviz_common::properties::StatusProperty::Error, "Topic",
@@ -116,6 +260,10 @@ void DENMDisplay::processMessage(etsi_its_denm_msgs::msg::DENM::ConstSharedPtr m
   else denms_.insert(std::make_pair(denm.getStationID(), denm)); 
   
   overlay_->show();
+
+  ++messages_received_;
+  setStatus(
+    rviz_common::properties::StatusProperty::Ok, "Topic", QString::number(messages_received_) + " messages received");
 }
 
 void DENMDisplay::update(float, float) {

--- a/etsi_its_rviz_plugins/src/displays/DENM/denm_render_object.cpp
+++ b/etsi_its_rviz_plugins/src/displays/DENM/denm_render_object.cpp
@@ -1,47 +1,90 @@
 #include "displays/DENM/denm_render_object.hpp"
+#include <variant>
+#include <type_traits>
+#include <cmath>
 
 namespace etsi_its_msgs
 {
 namespace displays
 {
 
-  DENMRenderObject::DENMRenderObject(etsi_its_denm_msgs::msg::DENM denm) {
-
+  DENMRenderObject::DENMRenderObject(const std::variant<
+      etsi_its_denm_msgs::msg::DENM,
+      etsi_its_denm_ts_msgs::msg::DENM
+    > & denm_variant)
+  {
     int zone;
     bool northp;
-    geometry_msgs::msg::PointStamped p = etsi_its_denm_msgs::access::getUTMPosition(denm, zone, northp);
-    header.frame_id = p.header.frame_id;
-  
-    uint64_t nanosecs = etsi_its_denm_msgs::access::getUnixNanosecondsFromReferenceTime(etsi_its_denm_msgs::access::getReferenceTime(denm));
-    header.stamp = rclcpp::Time(nanosecs);
+    geometry_msgs::msg::PointStamped p;
+    uint64_t nanosecs = 0;
+    uint32_t station_id_val = 0;
+    int station_type_val = 0;
+    std::string cause_code_type_val = "Not present";
+    std::string sub_cause_code_type_val = "Not present";
+    double heading_deg = 0*M_PI/180.0; // 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West
+    double vehicle_speed = 0.0;
 
-    station_id = etsi_its_denm_msgs::access::getStationID(denm);
-    if(denm.denm.situation_is_present) {
-      cause_code_type = etsi_its_denm_msgs::access::getCauseCodeType(denm);
-      sub_cause_code_type = etsi_its_denm_msgs::access::getSubCauseCodeType(denm);
-    } else {
+    if (const auto * r1 = std::get_if<etsi_its_denm_msgs::msg::DENM>(&denm_variant)) {
+      is_ts = false;
+      p = etsi_its_denm_msgs::access::getUTMPosition(*r1, zone, northp);
+      nanosecs = etsi_its_denm_msgs::access::getUnixNanosecondsFromReferenceTime(etsi_its_denm_msgs::access::getReferenceTime(*r1));
+      station_id_val = etsi_its_denm_msgs::access::getStationID(*r1);
+      station_type_val = etsi_its_denm_msgs::access::getStationType(*r1);
+      if(r1->denm.situation_is_present) {
+        cause_code_type_val = etsi_its_denm_msgs::access::getCauseCodeType(*r1);
+        sub_cause_code_type_val = etsi_its_denm_msgs::access::getSubCauseCodeType(*r1);
+      }
+      if (r1->denm.location_is_present && etsi_its_denm_msgs::access::getIsHeadingPresent(*r1)) {
+        heading_deg = (90-etsi_its_denm_msgs::access::getHeading(*r1))*M_PI/180.0;
+      }
+      if (r1->denm.location_is_present && etsi_its_denm_msgs::access::getIsSpeedPresent(*r1)) {
+        vehicle_speed = etsi_its_denm_msgs::access::getSpeed(*r1);
+      }
+    }
+    else if (const auto * r2 = std::get_if<etsi_its_denm_ts_msgs::msg::DENM>(&denm_variant)) {
+      is_ts = true;
+      p = etsi_its_denm_ts_msgs::access::getUTMPosition(*r2, zone, northp);
+      nanosecs = etsi_its_denm_ts_msgs::access::getUnixNanosecondsFromReferenceTime(etsi_its_denm_ts_msgs::access::getReferenceTime(*r2));
+      station_id_val = etsi_its_denm_ts_msgs::access::getStationID(*r2);
+      station_type_val = etsi_its_denm_ts_msgs::access::getStationType(*r2);
+      if(r2->denm.situation_is_present) {
+        cause_code_type_val = etsi_its_denm_ts_msgs::access::getCauseCodeType(*r2);
+        sub_cause_code_type_val = etsi_its_denm_ts_msgs::access::getSubCauseCodeType(*r2);
+      }
+      if (r2->denm.location_is_present && etsi_its_denm_ts_msgs::access::getIsHeadingPresent(*r2)) {
+        heading_deg = (90-etsi_its_denm_ts_msgs::access::getWGSHeading(*r2))*M_PI/180.0;
+      }
+      if (r2->denm.location_is_present && etsi_its_denm_ts_msgs::access::getIsSpeedPresent(*r2)) {
+        vehicle_speed = etsi_its_denm_ts_msgs::access::getSpeed(*r2);
+      }
+    } else { // unexpected variant content (minimal safe initialization)
+      is_ts = false;
+      header.frame_id = "";
+      header.stamp = rclcpp::Time(0);
+      station_id = 0;
+      station_type = 0;
       cause_code_type = "Not present";
       sub_cause_code_type = "Not present";
+      pose = geometry_msgs::msg::Pose();
+      dimensions = geometry_msgs::msg::Vector3();
+      speed = 0.0;
+      return;
     }
-    double heading; // 0.0° equals WGS84 North, 90.0° equals WGS84 East, 180.0° equals WGS84 South and 270.0° equals WGS84 West
-    if(denm.denm.location_is_present && etsi_its_denm_msgs::access::getIsHeadingPresent(denm)) {
-      heading = (90-etsi_its_denm_msgs::access::getHeading(denm))*M_PI/180.0;
-    }
-    else {
-      heading = 0*M_PI/180.0;
-    }
-    while(heading<0) heading+=2*M_PI;
+
+    // common initialization
+    header.frame_id = p.header.frame_id;
+    header.stamp = rclcpp::Time(nanosecs);
+    station_id = station_id_val;
+    station_type = station_type_val;
+    cause_code_type = cause_code_type_val;
+    sub_cause_code_type = sub_cause_code_type_val;
+    double heading = heading_deg;
+    while (heading < 0) heading += 2 * M_PI;
     pose.position = p.point;
     tf2::Quaternion orientation;
     orientation.setRPY(0.0, 0.0, heading);
     pose.orientation = tf2::toMsg(orientation);
-
-    if(denm.denm.location_is_present && etsi_its_denm_msgs::access::getIsSpeedPresent(denm)) {
-      speed = etsi_its_denm_msgs::access::getSpeed(denm);
-    }
-    else {
-      speed = 0;
-    }
+    speed = vehicle_speed;
   }
 
   bool DENMRenderObject::validateFloats() {
@@ -79,5 +122,8 @@ namespace displays
     return sub_cause_code_type;
   }
 
+  bool DENMRenderObject::isTS() {
+    return is_ts;
+  }
 }  // namespace displays
 }  // namespace etsi_its_msgs


### PR DESCRIPTION
Hello! This PR updates the DENM display so that it can subscribe to both DENM EN (Release 1) and DENM TS (Release 2) messages. This was previously mentioned in #109, and this implementation follows the same approach used there.