### PR TITLE
Added Code Generation Utils for converting ASN.1 NULL type elements.

### DIFF
--- a/utils/codegen/codegen-py/asn1CodeGenerationUtils.py
+++ b/utils/codegen/codegen-py/asn1CodeGenerationUtils.py
@@ -623,6 +623,21 @@ def asn1TypeToJinjaContext(asn1_type_name: str, asn1_type_info: Dict, asn1_types
             member_name = validRosField(f"CHOICE_{member['name']}", is_const=True)
             if "name" in asn1_type_info:
                 member_name = validRosField(f"CHOICE_{asn1_type_info['name']}_{member['name']}", is_const=True)
+            # Handle NULL CHOICE alternatives: no data field, only a selector constant
+            if member.get("type") == "NULL":
+                context["members"].append({
+                    "ros_msg_type": "uint8",
+                    "ros_field_name": "choice",
+                    "c_field_name": validCFieldAsGenByAsn1c(member["name"]),
+                    "disabled": True,
+                    "is_null_choice": True,
+                    "constants": [{
+                        "ros_msg_type": "uint8",
+                        "ros_field_name": validRosField(member_name, is_const=True),
+                        "ros_value": im
+                    }]
+                })
+                continue
             member_context = asn1TypeToJinjaContext(asn1_type_name, member, asn1_types, asn1_values, asn1_sets, asn1_classes)
             if member_context is None:
                 continue

--- a/utils/codegen/codegen-py/asn1ToConversionHeader.py
+++ b/utils/codegen/codegen-py/asn1ToConversionHeader.py
@@ -58,7 +58,7 @@ def parseCli():
 def loadJinjaTemplates() -> Dict[str, jinja2.environment.Template]:
     """Loads the jinja templates for conversion headers.
 
-    Templates available for types `CHOICE`, `CUSTOM`, `ENUMERATED`, `PRIMITIVE`, `SEQUENCE`, `SEQUENCE OF`.
+    Templates available for types `CHOICE`, `CUSTOM`, `ENUMERATED`, `NULL`, `PRIMITIVE`, `SEQUENCE`, `SEQUENCE OF`.
 
     Returns:
         Dict[str, jinja2.environment.Template]: jinja templates
@@ -70,6 +70,7 @@ def loadJinjaTemplates() -> Dict[str, jinja2.environment.Template]:
     jinja_templates["CHOICE"] = jinja_env.get_template("convertChoiceType.h.jinja2")
     jinja_templates["CUSTOM"] = jinja_env.get_template("convertCustomType.h.jinja2")
     jinja_templates["ENUMERATED"] = jinja_env.get_template("convertEnumeratedType.h.jinja2")
+    jinja_templates["NULL"] = jinja_env.get_template("convertNullType.h.jinja2")
     jinja_templates["PRIMITIVE"] = jinja_env.get_template("convertPrimitiveType.h.jinja2")
     jinja_templates["SEQUENCE"] = jinja_env.get_template("convertSequenceType.h.jinja2")
     jinja_templates["SEQUENCE OF"] = jinja_env.get_template("convertSequenceOfType.h.jinja2")
@@ -142,6 +143,9 @@ def exportConversionHeader(header: str, type_name: str, output_dir: str):
         type_name (str): type name / file name
         output_dir (str): output directory
     """
+
+    if header is None:
+        return
 
     # create output directory
     os.makedirs(output_dir, exist_ok=True)

--- a/utils/codegen/codegen-py/templates/convertNullType.h.jinja2
+++ b/utils/codegen/codegen-py/templates/convertNullType.h.jinja2
@@ -50,6 +50,7 @@ void toRos_{{ros_msg_type}}(const {{etsi_type}}_{{asn1_type_name}}_t& in, {{etsi
 }
 
 void toStruct_{{ros_msg_type}}(const {{etsi_type}}_msgs::{{ros_msg_type}}& in, {{etsi_type}}_{{asn1_type_name}}_t& out) {
+  (void)in;
   memset(&out, 0, sizeof({{etsi_type}}_{{asn1_type_name}}_t));
   // NULL type: no data to convert
 }

--- a/utils/codegen/codegen-py/templates/convertNullType.h.jinja2
+++ b/utils/codegen/codegen-py/templates/convertNullType.h.jinja2
@@ -46,6 +46,8 @@ namespace {{etsi_type}}_msgs = etsi_its_{{etsi_type}}_msgs::msg;
 namespace etsi_its_{{etsi_type}}_conversion {
 
 void toRos_{{ros_msg_type}}(const {{etsi_type}}_{{asn1_type_name}}_t& in, {{etsi_type}}_msgs::{{ros_msg_type}}& out) {
+  (void)in;
+  (void)out;
   // NULL type: no data to convert
 }
 

--- a/utils/codegen/codegen-py/templates/convertNullType.h.jinja2
+++ b/utils/codegen/codegen-py/templates/convertNullType.h.jinja2
@@ -39,11 +39,6 @@ SOFTWARE.
 #pragma once
 
 #include <etsi_its_{{etsi_type}}_coding/{{etsi_type}}_{{asn1_type_name}}.h>
-{% for member in unique_sorted_members -%}
-{%- if member.ros_field_name != "choice" -%}
-#include <etsi_its_{{etsi_type}}_conversion/convert{{member.ros_msg_type|replace("[]", "")}}.h>
-{% endif -%}
-{%- endfor -%}
 #include <etsi_its_{{etsi_type}}_msgs/msg/{{ros2_msg_type_file_name}}.hpp>
 namespace {{etsi_type}}_msgs = etsi_its_{{etsi_type}}_msgs::msg;
 
@@ -51,45 +46,12 @@ namespace {{etsi_type}}_msgs = etsi_its_{{etsi_type}}_msgs::msg;
 namespace etsi_its_{{etsi_type}}_conversion {
 
 void toRos_{{ros_msg_type}}(const {{etsi_type}}_{{asn1_type_name}}_t& in, {{etsi_type}}_msgs::{{ros_msg_type}}& out) {
-  switch (in.present) {
-{%- for member in members %}
-{%- if not member.is_choice_var %}
-{%- if member.is_null_choice %}
-  case {{etsi_type}}_{{asn1_type_name}}_PR_{{member.c_field_name}}:
-    out.choice = {{etsi_type}}_msgs::{{ros_msg_type}}::{{(member.constants | last).ros_field_name}};
-    break;
-{%- else %}
-  case {{etsi_type}}_{{asn1_type_name}}_PR_{{member.c_field_name}}:
-    toRos_{{member.ros_msg_type|replace("[]", "")}}(in.choice.{{member.c_field_name}}, out.{{member.ros_field_name}});
-    out.choice = {{etsi_type}}_msgs::{{ros_msg_type}}::{{(member.constants | last).ros_field_name}};
-    break;
-{%- endif %}
-{%- endif %}
-{%- endfor %}
-  default: break;
-  }
+  // NULL type: no data to convert
 }
 
 void toStruct_{{ros_msg_type}}(const {{etsi_type}}_msgs::{{ros_msg_type}}& in, {{etsi_type}}_{{asn1_type_name}}_t& out) {
   memset(&out, 0, sizeof({{etsi_type}}_{{asn1_type_name}}_t));
-  switch (in.choice) {
-{%- for member in members %}
-{%- if not member.is_choice_var %}
-{%- if member.is_null_choice %}
-  case {{etsi_type}}_msgs::{{ros_msg_type}}::{{(member.constants | last).ros_field_name}}:
-    out.present = {{etsi_type}}_{{asn1_type_name}}_PR::{{etsi_type}}_{{asn1_type_name}}_PR_{{member.c_field_name}};
-    break;
-{%- else %}
-  case {{etsi_type}}_msgs::{{ros_msg_type}}::{{(member.constants | last).ros_field_name}}:
-    toStruct_{{member.ros_msg_type|replace("[]", "")}}(in.{{member.ros_field_name}}, out.choice.{{member.c_field_name}});
-    out.present = {{etsi_type}}_{{asn1_type_name}}_PR::{{etsi_type}}_{{asn1_type_name}}_PR_{{member.c_field_name}};
-    break;
-{%- endif %}
-{%- endif %}
-{%- endfor %}
-  default: break;
-  }
+  // NULL type: no data to convert
 }
 
 }
-


### PR DESCRIPTION
I tried integrating the latest version of the MCM (TS_103561), which (at the moment) contains the
```
ManoeuvreOverallStrategy::= CHOICE {
	undefined NULL,
	transitToHumanDrivenMode NULL,
	transitToAutomatedDrivingMode NULL, 
...
```
with fields of ASN.1 type "NULL".
The current version of the CodeGen Utils does not handle this type and fails/ or creates wrong files.

I added the necessary handling.