### PR TITLE
Add ROS 2 Lyrical to CI

### DIFF
--- a/.github/workflows/bloom-release.yml
+++ b/.github/workflows/bloom-release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Release ROS 2
         uses: at-wat/bloom-release-action@v0
         with:
-          ros_distro: humble jazzy kilted lyrical
+          ros_distro: humble jazzy kilted lyrical rolling
           github_token_bloom: ${{ secrets.GH_TOKEN_FOR_BLOOM_RELEASE }}
           github_user: jpbusch
           git_user: Jean-Pierre Busch

--- a/.github/workflows/bloom-release.yml
+++ b/.github/workflows/bloom-release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Release ROS 2
         uses: at-wat/bloom-release-action@v0
         with:
-          ros_distro: humble jazzy kilted
+          ros_distro: humble jazzy kilted lyrical
           github_token_bloom: ${{ secrets.GH_TOKEN_FOR_BLOOM_RELEASE }}
           github_user: jpbusch
           git_user: Jean-Pierre Busch

--- a/.github/workflows/bloom-release.yml
+++ b/.github/workflows/bloom-release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Release ROS 2
         uses: at-wat/bloom-release-action@v0
         with:
-          ros_distro: humble jazzy kilted lyrical rolling
+          ros_distro: humble jazzy kilted lyrical
           github_token_bloom: ${{ secrets.GH_TOKEN_FOR_BLOOM_RELEASE }}
           github_user: jpbusch
           git_user: Jean-Pierre Busch

--- a/.github/workflows/docker-ros.yml
+++ b/.github/workflows/docker-ros.yml
@@ -64,16 +64,3 @@ jobs:
           rmw-implementation: rmw_zenoh_cpp
           command: ros2 launch etsi_its_conversion converter.launch.py
           enable-recursive-vcs-import: 'false'
-
-  ros2-rolling:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ika-rwth-aachen/docker-ros@main
-        with:
-          platform: amd64
-          target: run
-          image-tag: rolling
-          base-image: ros:rolling-ros-base
-          rmw-implementation: rmw_zenoh_cpp
-          command: ros2 launch etsi_its_conversion converter.launch.py
-          enable-recursive-vcs-import: 'false'

--- a/.github/workflows/docker-ros.yml
+++ b/.github/workflows/docker-ros.yml
@@ -64,3 +64,16 @@ jobs:
           rmw-implementation: rmw_zenoh_cpp
           command: ros2 launch etsi_its_conversion converter.launch.py
           enable-recursive-vcs-import: 'false'
+
+  ros2-rolling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ika-rwth-aachen/docker-ros@main
+        with:
+          platform: amd64
+          target: run
+          image-tag: ros2-rolling
+          base-image: ros:rolling-ros-base
+          rmw-implementation: rmw_zenoh_cpp
+          command: ros2 launch etsi_its_conversion converter.launch.py
+          enable-recursive-vcs-import: 'false'

--- a/.github/workflows/docker-ros.yml
+++ b/.github/workflows/docker-ros.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           platform: amd64
           target: run
-          image-tag: ros2-humble
+          image-tag: humble
           base-image: rwthika/ros2:humble
           command: ros2 launch etsi_its_conversion converter.launch.py
           enable-recursive-vcs-import: 'false'
@@ -32,7 +32,7 @@ jobs:
         with:
           platform: amd64
           target: run
-          image-tag: ros2-jazzy
+          image-tag: jazzy
           base-image: rwthika/ros2:jazzy
           rmw-implementation: rmw_zenoh_cpp
           command: ros2 launch etsi_its_conversion converter.launch.py
@@ -45,7 +45,7 @@ jobs:
         with:
           platform: amd64
           target: run
-          image-tag: ros2-kilted
+          image-tag: kilted
           base-image: rwthika/ros2:kilted
           rmw-implementation: rmw_zenoh_cpp
           command: ros2 launch etsi_its_conversion converter.launch.py
@@ -58,7 +58,7 @@ jobs:
         with:
           platform: amd64
           target: run
-          image-tag: ros2-lyrical
+          image-tag: lyrical
           enable-push-as-latest: 'true'
           base-image: ros:lyrical-ros-base # TODO: rwthika/ros2:lyrical
           rmw-implementation: rmw_zenoh_cpp
@@ -72,7 +72,7 @@ jobs:
         with:
           platform: amd64
           target: run
-          image-tag: ros2-rolling
+          image-tag: rolling
           base-image: ros:rolling-ros-base
           rmw-implementation: rmw_zenoh_cpp
           command: ros2 launch etsi_its_conversion converter.launch.py

--- a/.github/workflows/docker-ros.yml
+++ b/.github/workflows/docker-ros.yml
@@ -33,7 +33,6 @@ jobs:
           platform: amd64
           target: run
           image-tag: ros2-jazzy
-          enable-push-as-latest: 'true'
           base-image: rwthika/ros2:jazzy
           rmw-implementation: rmw_zenoh_cpp
           command: ros2 launch etsi_its_conversion converter.launch.py
@@ -48,6 +47,20 @@ jobs:
           target: run
           image-tag: ros2-kilted
           base-image: rwthika/ros2:kilted
+          rmw-implementation: rmw_zenoh_cpp
+          command: ros2 launch etsi_its_conversion converter.launch.py
+          enable-recursive-vcs-import: 'false'
+
+  ros2-lyrical:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ika-rwth-aachen/docker-ros@main
+        with:
+          platform: amd64
+          target: run
+          image-tag: ros2-lyrical
+          enable-push-as-latest: 'true'
+          base-image: ros:lyrical-ros-base # TODO: rwthika/ros2:lyrical
           rmw-implementation: rmw_zenoh_cpp
           command: ros2 launch etsi_its_conversion converter.launch.py
           enable-recursive-vcs-import: 'false'

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   industrial_ci:
-    name: ROS ${{ matrix.ROS_DISTRO }} (${{ matrix.ROS_REPO }})
+    name: ros2-${{ matrix.ROS_DISTRO }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,6 +18,7 @@ jobs:
           - humble
           - jazzy
           - kilted
+          - lyrical
         ROS_REPO:
           - main
     steps:

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -21,10 +21,6 @@ jobs:
           - lyrical
         ROS_REPO:
           - main
-        include:
-          - ROS_DISTRO: rolling
-            ROS_REPO: main
-            DOCKER_IMAGE: ros:rolling-ros-base # default image does not work with rolling
     steps:
       - uses: actions/checkout@v3
       - uses: ros-industrial/industrial_ci@master

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -19,6 +19,7 @@ jobs:
           - jazzy
           - kilted
           - lyrical
+          - rolling
         ROS_REPO:
           - main
     steps:

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -19,9 +19,12 @@ jobs:
           - jazzy
           - kilted
           - lyrical
-          - rolling
         ROS_REPO:
           - main
+        include:
+          - ROS_DISTRO: rolling
+            ROS_REPO: main
+            DOCKER_IMAGE: ros:rolling-ros-base # default image does not work with rolling
     steps:
       - uses: actions/checkout@v3
       - uses: ros-industrial/industrial_ci@master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ ros2-humble:
   variables:
     PLATFORM: amd64,arm64
     TARGET: dev,run
-    IMAGE_TAG: ros2-humble
+    IMAGE_TAG: humble
     BASE_IMAGE: rwthika/ros2:humble
     COMMAND: ros2 launch etsi_its_conversion converter.launch.py
     ENABLE_INDUSTRIAL_CI: 'true'
@@ -27,7 +27,7 @@ ros2-jazzy:
   variables:
     PLATFORM: amd64,arm64
     TARGET: dev,run
-    IMAGE_TAG: ros2-jazzy
+    IMAGE_TAG: jazzy
     BASE_IMAGE: rwthika/ros2:jazzy
     RMW_IMPLEMENTATION: rmw_zenoh_cpp
     COMMAND: ros2 launch etsi_its_conversion converter.launch.py
@@ -42,7 +42,7 @@ ros2-kilted:
   variables:
     PLATFORM: amd64,arm64
     TARGET: dev,run
-    IMAGE_TAG: ros2-kilted
+    IMAGE_TAG: kilted
     BASE_IMAGE: rwthika/ros2:kilted
     RMW_IMPLEMENTATION: rmw_zenoh_cpp
     COMMAND: ros2 launch etsi_its_conversion converter.launch.py
@@ -57,7 +57,7 @@ ros2-lyrical:
   variables:
     PLATFORM: amd64,arm64
     TARGET: dev,run
-    IMAGE_TAG: ros2-lyrical
+    IMAGE_TAG: lyrical
     ENABLE_PUSH_AS_LATEST: 'true'
     BASE_IMAGE: ros:lyrical-ros-base # TODO: rwthika/ros2:lyrical
     RMW_IMPLEMENTATION: rmw_zenoh_cpp
@@ -73,7 +73,7 @@ ros2-rolling:
   variables:
     PLATFORM: amd64,arm64
     TARGET: dev,run
-    IMAGE_TAG: ros2-rolling
+    IMAGE_TAG: rolling
     BASE_IMAGE: ros:rolling-ros-base
     RMW_IMPLEMENTATION: rmw_zenoh_cpp
     COMMAND: ros2 launch etsi_its_conversion converter.launch.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,3 +64,18 @@ ros2-lyrical:
     COMMAND: ros2 launch etsi_its_conversion converter.launch.py
     ENABLE_INDUSTRIAL_CI: 'true'
     ENABLE_RECURSIVE_VCS_IMPORT: 'false'
+
+ros2-rolling:
+  trigger:
+    include:
+      - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/main/.gitlab-ci/docker-ros.yml
+    strategy: depend
+  variables:
+    PLATFORM: amd64,arm64
+    TARGET: dev,run
+    IMAGE_TAG: ros2-rolling
+    BASE_IMAGE: ros:rolling-ros-base
+    RMW_IMPLEMENTATION: rmw_zenoh_cpp
+    COMMAND: ros2 launch etsi_its_conversion converter.launch.py
+    ENABLE_INDUSTRIAL_CI: 'true'
+    ENABLE_RECURSIVE_VCS_IMPORT: 'false'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,6 @@ ros2-jazzy:
     PLATFORM: amd64,arm64
     TARGET: dev,run
     IMAGE_TAG: ros2-jazzy
-    ENABLE_PUSH_AS_LATEST: 'true'
     BASE_IMAGE: rwthika/ros2:jazzy
     RMW_IMPLEMENTATION: rmw_zenoh_cpp
     COMMAND: ros2 launch etsi_its_conversion converter.launch.py
@@ -45,6 +44,22 @@ ros2-kilted:
     TARGET: dev,run
     IMAGE_TAG: ros2-kilted
     BASE_IMAGE: rwthika/ros2:kilted
+    RMW_IMPLEMENTATION: rmw_zenoh_cpp
+    COMMAND: ros2 launch etsi_its_conversion converter.launch.py
+    ENABLE_INDUSTRIAL_CI: 'true'
+    ENABLE_RECURSIVE_VCS_IMPORT: 'false'
+
+ros2-lyrical:
+  trigger:
+    include:
+      - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/main/.gitlab-ci/docker-ros.yml
+    strategy: depend
+  variables:
+    PLATFORM: amd64,arm64
+    TARGET: dev,run
+    IMAGE_TAG: ros2-lyrical
+    ENABLE_PUSH_AS_LATEST: 'true'
+    BASE_IMAGE: ros:lyrical-ros-base # TODO: rwthika/ros2:lyrical
     RMW_IMPLEMENTATION: rmw_zenoh_cpp
     COMMAND: ros2 launch etsi_its_conversion converter.launch.py
     ENABLE_INDUSTRIAL_CI: 'true'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,18 +64,3 @@ ros2-lyrical:
     COMMAND: ros2 launch etsi_its_conversion converter.launch.py
     ENABLE_INDUSTRIAL_CI: 'true'
     ENABLE_RECURSIVE_VCS_IMPORT: 'false'
-
-ros2-rolling:
-  trigger:
-    include:
-      - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/main/.gitlab-ci/docker-ros.yml
-    strategy: depend
-  variables:
-    PLATFORM: amd64,arm64
-    TARGET: dev,run
-    IMAGE_TAG: rolling
-    BASE_IMAGE: ros:rolling-ros-base
-    RMW_IMPLEMENTATION: rmw_zenoh_cpp
-    COMMAND: ros2 launch etsi_its_conversion converter.launch.py
-    ENABLE_INDUSTRIAL_CI: 'true'
-    ENABLE_RECURSIVE_VCS_IMPORT: 'false'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/codegen.yml"><img src="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/codegen.yml/badge.svg"/></a>
   <a href="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/docker-ros.yml"><img src="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/docker-ros.yml/badge.svg"/></a>
   <a href="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/doc.yml"><img src="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/doc.yml/badge.svg"/></a>
-  <img src="https://img.shields.io/badge/ROS 2-humble|jazzy|kilted|lyrical-293754"/>
+  <img src="https://img.shields.io/badge/ROS 2-humble|jazzy|kilted|lyrical|rolling-293754"/>
   <img src="https://img.shields.io/badge/V2X-CAM|CPM|DENM|IVIM|MAPEM|MCM|SPATEM|VAM-aqua"/>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/codegen.yml"><img src="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/codegen.yml/badge.svg"/></a>
   <a href="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/docker-ros.yml"><img src="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/docker-ros.yml/badge.svg"/></a>
   <a href="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/doc.yml"><img src="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/doc.yml/badge.svg"/></a>
-  <img src="https://img.shields.io/badge/ROS 2-humble|jazzy|kilted|lyrical|rolling-293754"/>
+  <img src="https://img.shields.io/badge/ROS 2-humble|jazzy|kilted|lyrical-293754"/>
   <img src="https://img.shields.io/badge/V2X-CAM|CPM|DENM|IVIM|MAPEM|MCM|SPATEM|VAM-aqua"/>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/codegen.yml"><img src="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/codegen.yml/badge.svg"/></a>
   <a href="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/docker-ros.yml"><img src="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/docker-ros.yml/badge.svg"/></a>
   <a href="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/doc.yml"><img src="https://github.com/ika-rwth-aachen/etsi_its_messages/actions/workflows/doc.yml/badge.svg"/></a>
-  <img src="https://img.shields.io/badge/ROS 2-humble|jazzy|kilted-blueviolet"/>
+  <img src="https://img.shields.io/badge/ROS 2-humble|jazzy|kilted|lyrical-293754"/>
   <img src="https://img.shields.io/badge/V2X-CAM|CPM|DENM|IVIM|MAPEM|MCM|SPATEM|VAM-aqua"/>
 </p>
 


### PR DESCRIPTION
Lyrical is currently failing cause at least `rviz_satellite` is not yet available for ROS 2 Lyrical on Ubuntu 26.04