### PR TITLE
cmake: replace deprecated ament_target_dependencies invocations

### DIFF
--- a/etsi_its_conversion/etsi_its_conversion/CMakeLists.txt
+++ b/etsi_its_conversion/etsi_its_conversion/CMakeLists.txt
@@ -39,21 +39,21 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>)
 target_compile_features(${PROJECT_NAME} PUBLIC c_std_99 cxx_std_17)
 
-ament_target_dependencies(${PROJECT_NAME}
-  etsi_its_cam_conversion
-  etsi_its_cam_ts_conversion
-  etsi_its_conversion_srvs
-  etsi_its_cpm_ts_conversion
-  etsi_its_denm_conversion
-  etsi_its_denm_ts_conversion
-  etsi_its_ivim_ts_conversion
-  etsi_its_mapem_ts_conversion
-  etsi_its_mcm_uulm_conversion
-  etsi_its_spatem_ts_conversion
-  etsi_its_vam_ts_conversion
-  rclcpp
-  rclcpp_components
-  udp_msgs
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${etsi_its_cam_conversion_TARGETS}
+  ${etsi_its_cam_ts_conversion_TARGETS}
+  ${etsi_its_conversion_srvs_TARGETS}
+  ${etsi_its_cpm_ts_conversion_TARGETS}
+  ${etsi_its_denm_conversion_TARGETS}
+  ${etsi_its_denm_ts_conversion_TARGETS}
+  ${etsi_its_ivim_ts_conversion_TARGETS}
+  ${etsi_its_mapem_ts_conversion_TARGETS}
+  ${etsi_its_mcm_uulm_conversion_TARGETS}
+  ${etsi_its_spatem_ts_conversion_TARGETS}
+  ${etsi_its_vam_ts_conversion_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_components::component
+  ${udp_msgs_TARGETS}
 )
 
 install(TARGETS ${PROJECT_NAME}

--- a/etsi_its_msgs/etsi_its_msgs/CMakeLists.txt
+++ b/etsi_its_msgs/etsi_its_msgs/CMakeLists.txt
@@ -7,16 +7,35 @@ find_package(etsi_its_cam_ts_msgs REQUIRED)
 find_package(etsi_its_cpm_ts_msgs REQUIRED)
 find_package(etsi_its_denm_msgs REQUIRED)
 find_package(etsi_its_denm_ts_msgs REQUIRED)
+find_package(etsi_its_ivim_ts_msgs REQUIRED)
 find_package(etsi_its_mapem_ts_msgs REQUIRED)
 find_package(etsi_its_spatem_ts_msgs REQUIRED)
 find_package(etsi_its_vam_ts_msgs REQUIRED)
 
+# aggregate target so that downstream packages can link against all ETSI ITS message types
+add_library(${PROJECT_NAME} INTERFACE)
+target_link_libraries(${PROJECT_NAME} INTERFACE
+  ${etsi_its_cam_msgs_TARGETS}
+  ${etsi_its_cam_ts_msgs_TARGETS}
+  ${etsi_its_cpm_ts_msgs_TARGETS}
+  ${etsi_its_denm_msgs_TARGETS}
+  ${etsi_its_denm_ts_msgs_TARGETS}
+  ${etsi_its_ivim_ts_msgs_TARGETS}
+  ${etsi_its_mapem_ts_msgs_TARGETS}
+  ${etsi_its_spatem_ts_msgs_TARGETS}
+  ${etsi_its_vam_ts_msgs_TARGETS}
+)
+install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
+)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   etsi_its_cam_msgs
   etsi_its_cam_ts_msgs
   etsi_its_cpm_ts_msgs
   etsi_its_denm_msgs
   etsi_its_denm_ts_msgs
+  etsi_its_ivim_ts_msgs
   etsi_its_mapem_ts_msgs
   etsi_its_spatem_ts_msgs
   etsi_its_vam_ts_msgs

--- a/etsi_its_msgs_utils/CMakeLists.txt
+++ b/etsi_its_msgs_utils/CMakeLists.txt
@@ -53,14 +53,15 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(${PROJECT_NAME}-test test/test_access.cpp)
   target_include_directories(${PROJECT_NAME}-test PUBLIC test
+    ${GeographicLib_INCLUDE_DIRS}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
-  ament_target_dependencies(${PROJECT_NAME}-test
-    etsi_its_msgs
-    GeographicLib
-    geometry_msgs
-    tf2_geometry_msgs
+  target_link_libraries(${PROJECT_NAME}-test
+    ${etsi_its_msgs_TARGETS}
+    ${GeographicLib_LIBRARIES}
+    ${geometry_msgs_TARGETS}
+    ${tf2_geometry_msgs_TARGETS}
   )
 endif()
 

--- a/etsi_its_rviz_plugins/CMakeLists.txt
+++ b/etsi_its_rviz_plugins/CMakeLists.txt
@@ -62,28 +62,24 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 target_link_libraries(${PROJECT_NAME} PUBLIC
   rviz_ogre_vendor::OgreMain
   rviz_ogre_vendor::OgreOverlay
+  rclcpp::rclcpp
+  ${etsi_its_cam_msgs_TARGETS}
+  ${etsi_its_cam_ts_msgs_TARGETS}
+  ${etsi_its_cpm_ts_msgs_TARGETS}
+  ${etsi_its_denm_msgs_TARGETS}
+  ${etsi_its_denm_ts_msgs_TARGETS}
+  ${etsi_its_mapem_ts_msgs_TARGETS}
+  ${etsi_its_spatem_ts_msgs_TARGETS}
+  ${etsi_its_msgs_utils_TARGETS}
+  rviz_common::rviz_common
+  rviz_default_plugins::rviz_default_plugins
+  rviz_rendering::rviz_rendering
+  tf2::tf2
+  ${tf2_geometry_msgs_TARGETS}
+  tf2_ros::tf2_ros
 )
 
 pluginlib_export_plugin_description_file(rviz_common plugins_description.xml)
-
-ament_target_dependencies(${PROJECT_NAME}
-  PUBLIC
-  rclcpp
-  etsi_its_cam_msgs
-  etsi_its_cam_ts_msgs
-  etsi_its_cpm_ts_msgs
-  etsi_its_denm_msgs
-  etsi_its_denm_ts_msgs
-  etsi_its_mapem_ts_msgs
-  etsi_its_spatem_ts_msgs
-  etsi_its_msgs_utils
-  rviz_common
-  rviz_default_plugins
-  rviz_rendering
-  tf2
-  tf2_geometry_msgs
-  tf2_ros
-)
 
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 


### PR DESCRIPTION
Use of `ament_target_dependencies` has been deprecated in favour of `target_link_libraries`, so I refactored the packages accordingly. The base packages compile for humble, jazzy and lyrical; the rviz issue #124 is not solved by this PR.